### PR TITLE
fix 'distribution' in sample rules as a list and not as a dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ For example:
 "data": {
     "sample_dist": [{
         "path": "train",
-        "distribution": {
-            "News": "0.7",
-            "IT": "0.3"
-        }
+        "distribution": [
+            ["News", 0.7],
+            ["IT", 0.3],
+            ["Dialog", "*"]
+        ]
     }],
     "version": "1",
     "sample": 10000,

--- a/nmtwizard/sampler.py
+++ b/nmtwizard/sampler.py
@@ -117,11 +117,13 @@ def sample(gsample, sample_dist, source_dir, target_dir, src_suffix, tgt_suffix)
     for (fp, f, ri) in allfiles:
         size = -1
         w = None
-        # distribution is a list of ["pattern", weight, "options", ...]
+        # distribution is a list of ["pattern", weight, "addtl options"]
         for rule in sample_dist[ri]['distribution']:
             pattern = rule[0]
             weight = rule[1]
-            extra = rule[2:]
+            extra = None
+            if len(rule) > 2:
+                extra = rule[2]
             if weight != '*' and isinstance(weight, six.string_types):
                 weight = float(weight)
             if pattern == '*' or re.search(pattern, f):
@@ -210,9 +212,11 @@ def main():
     if not isinstance(sample_dist, list):
         raise ValueError('sample_dist should a collection of {path, [sample_rules]}')
 
-    sample(args.gsample, sample_dist,
-           args.source_dir, args.target_dir,
-           args.src_suffix, args.tgt_suffix)
+    res, metadata = sample(args.gsample, sample_dist,
+                           args.source_dir, args.target_dir,
+                           args.src_suffix, args.tgt_suffix)
+    print('res=', json.dumps(res))
+    print('metadata=', json.dumps(metadata))
 
 if __name__ == "__main__":
     main()

--- a/nmtwizard/sampler.py
+++ b/nmtwizard/sampler.py
@@ -117,14 +117,13 @@ def sample(gsample, sample_dist, source_dir, target_dir, src_suffix, tgt_suffix)
     for (fp, f, ri) in allfiles:
         size = -1
         w = None
-        for pattern, value in six.iteritems(sample_dist[ri]['distribution']):
-            if isinstance(value, six.string_types):
-                field = re.split(r'\s+', value)
-                weight = float(field[0])
-                extra = field[1] if len(field) > 1 else None
-            else:
-                weight = float(value)
-                extra = None
+        # distribution is a list of ["pattern", weight, "options", ...]
+        for rule in sample_dist[ri]['distribution']:
+            pattern = rule[0]
+            weight = rule[1]
+            extra = rule[2:]
+            if weight != '*' and isinstance(weight, six.string_types):
+                weight = float(weight)
             if pattern == '*' or re.search(pattern, f):
                 size = _countLine((fp, f, ri))
                 w = {"pattern": pattern, "weight": weight, "extra": extra}
@@ -161,7 +160,7 @@ def sample(gsample, sample_dist, source_dir, target_dir, src_suffix, tgt_suffix)
         else:
             metadata[f[1]] = w["extra"]
             if w["weight"] == '*':
-                samplefile.append((f[0], f[1], c, c, w[1]))
+                samplefile.append((f[0], f[1], c, c, w["pattern"]))
                 summary_by_pattern[w["pattern"]] += c
                 summary_by_file[f[0]] = c
             else:
@@ -195,8 +194,12 @@ def main():
                         help='suffix of target language files')
     parser.add_argument('-g', '--gsample', type=int, required=True,
                         help='number of sentences to sample')
+    parser.add_argument('-l', '--log_level', default='INFO',
+                        help='log level')
 
     args = parser.parse_args()
+
+    logger.setLevel(args.log_level)
 
     if not os.path.exists(args.sample_dist) or not os.path.isfile(args.sample_dist):
         raise ValueError('distribution file %s does not exist or is not a file' % args.sample_dist)


### PR DESCRIPTION
current implementation is diverging, from [definition](http://opennmt.net/OpenNMT/training/sampling/#sampling-distribution-rules) by losing rule order