### PR TITLE
normalizing nmt-wizard routes

### DIFF
--- a/nmtwizard/beat_service.py
+++ b/nmtwizard/beat_service.py
@@ -27,7 +27,7 @@ def start_beat_service(container_id, url, task_id, interval=30):
     }
 
     def _beat():
-        requests.get('%s/beat/%s' % (url, task_id), params=request_params)
+        requests.get('%s/task/beat/%s' % (url, task_id), params=request_params)
 
     def _beat_loop():
         while True:

--- a/nmtwizard/beat_service.py
+++ b/nmtwizard/beat_service.py
@@ -27,7 +27,7 @@ def start_beat_service(container_id, url, task_id, interval=30):
     }
 
     def _beat():
-        requests.get('%s/task/beat/%s' % (url, task_id), params=request_params)
+        requests.put('%s/task/beat/%s' % (url, task_id), params=request_params)
 
     def _beat_loop():
         while True:


### PR DESCRIPTION
| `PUT`     | `task/beat/{task_id}`                  |        | Provides a `beat` back to the launcher to notify the task activity and announce the next beat to expect |