### PR TITLE
Let utilities cleanly declare their arguments

### DIFF
--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -189,10 +189,7 @@ class Framework(Utility):
                 model_path=model_path,
                 gpuid=gpuid)
 
-    def exec_function(self, args):
-        """Main entrypoint."""
-        parser = argparse.ArgumentParser()
-
+    def declare_arguments(self, parser):
         subparsers = parser.add_subparsers(help='Run type', dest='cmd')
         parser_train = subparsers.add_parser('train', help='Run a training.')
 
@@ -219,7 +216,8 @@ class Framework(Utility):
                                        help='Preprocess data into a model.')
         parser.build_vocab = subparsers.add_parser('buildvocab', help='Build vocabularies.')
 
-        args = parser.parse_args(args=args)
+    def exec_function(self, args):
+        """Main entrypoint."""
         if self._config is None and self._model is None:
             parser.error('at least one of --config or --model options must be set')
 

--- a/nmtwizard/utility.py
+++ b/nmtwizard/utility.py
@@ -84,6 +84,10 @@ class Utility(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def declare_arguments(self, parser):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def exec_function(self, args):
         """Launch the utility with provided params
         """
@@ -123,8 +127,7 @@ class Utility(object):
         parser.add_argument('--no_push', default=False, action='store_true',
                             help='Do not push model.')
 
-        parser.add_argument('utility_args', nargs=argparse.REMAINDER, help=self._parser.format_usage())
-
+        self.declare_arguments(parser)
         args = parser.parse_args(args=args)
 
         if args.task_id is None:
@@ -163,11 +166,10 @@ class Utility(object):
         self._model = args.model
         self._no_push = args.no_push
 
-        logger.info('Starting executing utility %s=%s with args [%s]',
-                    self.name, args.image, " ".join(args.utility_args))
+        logger.info('Starting executing utility %s=%s', self.name, args.image)
         start_time = time.time()
 
-        self.exec_function(args.utility_args)
+        self.exec_function(args)
 
         end_time = time.time()
         logger.info('Finished executing utility in %s seconds', str(end_time-start_time))


### PR DESCRIPTION
The current utilities arguments handling is not very robust. We should instead let the utilities declare their arguments in the main `ArgumentParser`.

cc @monsieurzhang.