### PR TITLE
fix translating larger test files

### DIFF
--- a/frameworks/google_translate/entrypoint.py
+++ b/frameworks/google_translate/entrypoint.py
@@ -19,31 +19,31 @@ class GoogleTranslateFramework(CloudTranslationFramework):
                 f.write(credentials)
             os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = credential_path
         self._client = translate.Client()
-        self._char_counts = 0
+        self.max_retry = 5
         self._GOOGLE_LIMIT_SIZE = 100000
         self._GOOGLE_LIMIT_TIME = 100
 
-    def get_char_counts(self, batch):
-        counts = 0
-        for line in batch:
-            counts += len(line)
-        return counts
-
     def translate_batch(self, batch, source_lang, target_lang):
-        current_batch_char = self.get_char_counts(batch)
-        if self._char_counts + current_batch_char > self._GOOGLE_LIMIT_SIZE:
-            self._char_counts = current_batch_char
-            print("Exceeding the Google API limit %d, sleep %d seconds ..." % (self._GOOGLE_LIMIT_SIZE, self._GOOGLE_LIMIT_TIME))
-            time.sleep(self._GOOGLE_LIMIT_TIME)
-            time.sleep(1)
-        else:
-            self._char_counts += current_batch_char
+        translation = None
+        retry = 0
+        while retry < self.max_retry:
+            try:
+                translation = self._client.translate(
+                    batch,
+                    source_language=source_lang,
+                    target_language=target_lang,
+                    format_='text')
+            except Exception as e:
+                if e.code == 403 and "User Rate Limit Exceeded" in e.message:
+                    print("Exceeding the Google API limit %d, sleep %d seconds ..." % (self._GOOGLE_LIMIT_SIZE, self._GOOGLE_LIMIT_TIME))
+                    time.sleep(self._GOOGLE_LIMIT_TIME)
+                    time.sleep(1)
+                    retry += 1
+                    continue
+                else:
+                    raise RuntimeError('Error code %d: %s' % (e.code, e.message))
+            break
 
-        translation = self._client.translate(
-            batch,
-            source_language=source_lang,
-            target_language=target_lang,
-            format_='text')
         for trans in translation:
             yield trans['translatedText']
 


### PR DESCRIPTION
Google has a limit per 100 seconds 100000 chars.
https://cloud.google.com/translate/quotas

Sleep 100 seconds when needed when translating larger test files.