### PR TITLE
fix: if remote_folder is empty, create local_folder

### DIFF
--- a/nmtwizard/storages/generic.py
+++ b/nmtwizard/storages/generic.py
@@ -92,6 +92,8 @@ class Storage(object):
             directory = self.isdir(remote_path)
 
         if directory:
+            if not os.path.isdir(local_path):
+                os.makedirs(local_path)
             with lock(local_path):
                 allfiles = {}
                 for root, dirs, files in os.walk(local_path):

--- a/nmtwizard/storages/generic.py
+++ b/nmtwizard/storages/generic.py
@@ -87,6 +87,9 @@ class Storage(object):
             LOGGER.warning('%s does not exist on the remote but %s exists locally, continuing',
                            remote_path, local_path)
             return
+        if not self.exists(remote_path):
+            LOGGER.warning('%s does not exist on the remote', remote_path)
+            return
 
         if directory is None:
             directory = self.isdir(remote_path)

--- a/nmtwizard/storages/generic.py
+++ b/nmtwizard/storages/generic.py
@@ -87,9 +87,12 @@ class Storage(object):
             LOGGER.warning('%s does not exist on the remote but %s exists locally, continuing',
                            remote_path, local_path)
             return
-        if not self.exists(remote_path):
-            LOGGER.warning('%s does not exist on the remote', remote_path)
-            return
+        try:
+            if not self.exists(remote_path):
+                LOGGER.warning('%s does not exist on the remote', remote_path)
+                return
+        except NotImplementedError:
+            pass
 
         if directory is None:
             directory = self.isdir(remote_path)


### PR DESCRIPTION
when remote_folder is empty, there is no chance to scan the files inside remote_folder.
As a result, the local_folder is missing, which will cause an error.