### PR TITLE
Functions to get the op type and parameters from the configuration

### DIFF
--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -8,6 +8,19 @@ from nmtwizard.logger import get_logger
 
 logger = get_logger(__name__)
 
+def get_operator_type(config):
+    """Returns the operator type from the configuration."""
+    op = config.get("op")
+    if op is None:
+        raise ValueError("Missing 'op' field in operator configuration: %s" % str(config))
+    return op
+
+def get_operator_params(config):
+    """Returns the operator parameters from the configuration."""
+    config = config.copy()
+    config.pop("op", None)
+    return config
+
 @six.add_metaclass(abc.ABCMeta)
 class Operator(object):
     """Base class for preprocessing operators."""
@@ -54,23 +67,23 @@ class Pipeline(Operator):
 
     def _build_pipeline(self, config, preprocess_exit_step):
         for i, op in enumerate(config):
-            operator = self._build_operator(i, op)
+            operator = self._build_operator(op)
             if operator:
                 self._ops.append(operator)
             if preprocess_exit_step and i == preprocess_exit_step:
                 break
 
-    def _build_operator(self, step, operator_config):
-        if not "op" in operator_config:
-            raise RuntimeError('Step %d in \'preprocess\' doesn\'t have mandatory \'op\' option.' % step)
-        if operator_config["op"] == "length_filter":
-            return LengthFilter(operator_config)
-        if operator_config["op"] == "tokenization":
-            return Tokenizer(operator_config, self.state)
+    def _build_operator(self, operator_config):
+        op = get_operator_type(operator_config)
+        params = get_operator_params(operator_config)
+        if op == "length_filter":
+            return LengthFilter(params)
+        if op == "tokenization":
+            return Tokenizer(params, self.state)
         # TODO : all other operators
         else:
             # TODO : warning or error ?
-            logger.warning('Unknown operator \'%s\' will be ignored.' % operator_config["op"])
+            logger.warning('Unknown operator \'%s\' will be ignored.' % op)
             return None
 
     def __call__(self, tu_batch):

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -35,12 +35,11 @@ def _generate_models(config, tokenization_step, corpus_dir, data_dir, option):
 
 def _get_tok_configs(config):
     tok_configs = []
-    if "preprocess" in config:
-        for i, op in enumerate(config["preprocess"]):
-            if not "op" in op:
-                raise RuntimeError('Every step in \'preprocess\' must have a mandatory \'op\' option.')
-            if op["op"] == "tokenization":
-                tok_configs.append(i)
+    preprocess_config = config.get("preprocess")
+    if preprocess_config is not None:
+        for operator_config in preprocess_config:
+            if prepoperator.get_operator_type(operator_config) == "tokenization":
+                tok_configs.append(prepoperator.get_operator_params(operator_config))
     return tok_configs
 
 
@@ -52,16 +51,13 @@ def generate_vocabularies(config, corpus_dir, data_dir):
     if not tok_configs:
         raise RuntimeError('No \'tokenization\' operator in preprocess configuration, cannot build vocabularies.)')
 
-    for i in tok_configs:
-        tok_config = config['preprocess'][i]
+    for i, tok_config in enumerate(tok_configs):
         if ('source' not in tok_config or 'target' not in tok_config) and 'multi' not in tok_config :
             raise RuntimeError('Each \'tokenization\' operator should contain \
                                 either both \'source\' and \'target\' fields \
                                 or \'multi\' field.')
 
         for side in tok_config:
-            if side == "op":
-                continue
             build_vocab = tok_config[side].get('build_vocabulary')
             if build_vocab:
                 if tok_config[side].get('vocabulary_path', {}):


### PR DESCRIPTION
In particular, we should remove the "op" field from the parameters so
that the operator does not need to manipulate this extra field.