### PR TITLE
Allow frameworks to take responsibility over the request batching

### DIFF
--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -53,6 +53,11 @@ class Framework(utility.Utility):
     def name(self):
         return "NMT framework"
 
+    @property
+    def has_own_request_batching(self):
+        """Returns True if the framework applies its own batching logic during serving."""
+        return False
+
     @abc.abstractmethod
     def train(self,
               config,
@@ -642,7 +647,8 @@ class Framework(utility.Utility):
             lambda: self.serve(local_config, model_path, gpuid=gpuid),
             self._preprocess_input,
             self.forward_request,
-            self._postprocess_output)
+            self._postprocess_output,
+            rebatch_request=not self.has_own_request_batching)
 
     def preprocess(self, config, storage):
         logger.info('Starting preprocessing data ')

--- a/nmtwizard/serving.py
+++ b/nmtwizard/serving.py
@@ -220,9 +220,8 @@ def run_request(request,
         options = request.get('options', {})
         options.setdefault('timeout', timeout)
         config = finalize_config(config, override=options.get('config'))
-        if rebatch_request:
-            max_batch_size = options.get('max_batch_size', max_batch_size)
-        elif max_batch_size is not None:
+        max_batch_size = options.get('max_batch_size', max_batch_size)
+        if not rebatch_request and max_batch_size is not None:
             options['max_batch_size'] = max_batch_size
             max_batch_size = None
 

--- a/nmtwizard/serving.py
+++ b/nmtwizard/serving.py
@@ -64,7 +64,8 @@ def start_server(host,
                  backend_service_fn,
                  preprocess_fn,
                  translate_fn,
-                 postprocess_fn):
+                 postprocess_fn,
+                 rebatch_request=True):
     """Start a serving service.
 
     This function will only return on SIGINT or SIGTERM signals.
@@ -78,6 +79,9 @@ def start_server(host,
       translation_fn: A callable that forwards the request to the translation backend.
       postprocess_fn: A callable taking (serving_state, src_tokens, tgt_tokens, config)
         and returning text.
+      rebatch_request: If True, incoming requests are rebatched according to
+        max_batch_size. Otherwise, max_batch_size is passed as a translation option
+        to translate_fn which takes responsibility over batching.
     """
     global backend_process
     global backend_info
@@ -86,8 +90,8 @@ def start_server(host,
     global_max_batch_size = None
     serving_config = config.get('serving')
     if serving_config is not None and isinstance(serving_config, dict):
-        global_timeout = config.get('timeout')
-        global_max_batch_size = config.get('max_batch_size')
+        global_timeout = serving_config.get('timeout')
+        global_max_batch_size = serving_config.get('max_batch_size')
 
     class ServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         def _send_response(self, data):
@@ -132,6 +136,7 @@ def start_server(host,
                     functools.partial(translate_fn, backend_info),
                     functools.partial(postprocess_fn, serving_state),
                     config=config,
+                    rebatch_request=rebatch_request,
                     max_batch_size=global_max_batch_size,
                     timeout=global_timeout)
             except ValueError as e:
@@ -193,6 +198,7 @@ def run_request(request,
                 translate_fn,
                 postprocess_fn,
                 config=None,
+                rebatch_request=True,
                 max_batch_size=None,
                 timeout=None):
     """Runs a translation request."""
@@ -214,7 +220,11 @@ def run_request(request,
         options = request.get('options', {})
         options.setdefault('timeout', timeout)
         config = finalize_config(config, override=options.get('config'))
-        max_batch_size = options.get('max_batch_size', max_batch_size)
+        if rebatch_request:
+            max_batch_size = options.get('max_batch_size', max_batch_size)
+        elif max_batch_size is not None:
+            options['max_batch_size'] = max_batch_size
+            max_batch_size = None
 
         examples = preprocess_examples(src, preprocess_fn, config=config)
         outputs = translate_examples(

--- a/test/test_serving.py
+++ b/test/test_serving.py
@@ -249,6 +249,7 @@ def test_run_request():
         assert options is not None
         assert "config" in options  # Request options are fowarded.
         assert "mode" in options
+        assert options["max_batch_size"] == 1
         return [
             [_make_output((target if target is not None else []) + list(reversed(source)))]
             for source, target in zip(source_tokens, target_tokens)]
@@ -266,5 +267,12 @@ def test_run_request():
         }
     }
 
-    result = serving.run_request(request, preprocess, translate, postprocess, config=config)
+    result = serving.run_request(
+        request,
+        preprocess,
+        translate,
+        postprocess,
+        config=config,
+        rebatch_request=False,
+        max_batch_size=1)
     assert result == {'tgt': [[{'text': '1 2 c b a'}], [{'text': 'z_y_x'}]]}


### PR DESCRIPTION
Some frameworks can make optimizations when the number of examples in the request is greater than `max_batch_size`. For example, CTranslate2 is able to sort examples by length to improve translation efficiency.