### PR TITLE
Pass global configuration and process type as options for each operator

### DIFF
--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -46,7 +46,7 @@ def get_operator_params(config):
     return config
 
 
-def build_operator(operator_config, state):
+def build_operator(operator_config, global_config, process_type, state):
     """Creates an operator instance from its configuration."""
 
     operator_type = get_operator_type(operator_config)
@@ -55,9 +55,7 @@ def build_operator(operator_config, state):
         logger.warning('Unknown operator \'%s\' will be ignored.' % operator_type)
         return None
     operator_params = get_operator_params(operator_config)
-    if operator_cls.is_stateful():
-        return operator_cls(operator_params, state)
-    return operator_cls(operator_params)
+    return operator_cls(operator_params, global_config, process_type, state)
 
 
 class ProcessType(object):
@@ -94,8 +92,10 @@ class Pipeline(object):
 
 
     def _add_op_list(self, op_list_config, exit_step=None):
-        for i, op in enumerate(op_list_config):
-            operator = build_operator(op, self.build_state)
+        # Parameters from global configuration that can be useful for individual operators.
+
+        for i, op_config in enumerate(op_list_config):
+            operator = build_operator(op_config, self._config, self._process_type, self.build_state)
             if operator and operator.is_applied_for(self._process_type):
                 self._ops.append(operator)
             if exit_step and i == exit_step:
@@ -104,6 +104,7 @@ class Pipeline(object):
 
     def _build_pipeline(self, config, preprocess_exit_step=None):
         self._ops = []
+        self._config = config
         preprocess_config = config.get("preprocess")
         if preprocess_config:
             self._add_op_list(preprocess_config, exit_step=preprocess_exit_step)
@@ -159,10 +160,6 @@ class Operator(object):
     def is_applied_for(process_type):
         return True
 
-    @staticmethod
-    def is_stateful():
-        return True
-
 
 class TUOperator(Operator):
     """Base class for operations iterating on each TU in a batch."""
@@ -203,7 +200,7 @@ class Filter(TUOperator):
 @register_operator("length_filter")
 class LengthFilter(Filter):
 
-    def __init__(self, config):
+    def __init__(self, config, global_config, process_type):
 
         super(LengthFilter, self).__init__()
 
@@ -216,15 +213,11 @@ class LengthFilter(Filter):
         if self._target_max:
             self._criteria.append(lambda x:len(x.tgt_detok) > self._target_max)
 
-    @staticmethod
-    def is_stateful():
-        return False
-
 
 @register_operator("tokenization")
 class Tokenizer(Operator):
 
-    def __init__(self, tok_config, build_state):
+    def __init__(self, tok_config, global_config, process_type, build_state):
         self._src_tok_config = tok_config.get("source") or tok_config.get("multi")
         self._tgt_tok_config = tok_config.get("target") or tok_config.get("multi")
 
@@ -278,7 +271,7 @@ class Tokenizer(Operator):
 @register_operator("alignment")
 class Aligner(Operator):
 
-    def __init__(self, align_config, build_state):
+    def __init__(self, align_config, global_config, process_type, build_state):
         self._align_config = align_config
         self._aligner = None
         build_state['write_alignment'] = self._align_config.get('write_alignment', False)

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -383,7 +383,7 @@ def test_replace_tokens(tmpdir):
     @prepoperator.register_operator("repl")
     class ReplaceOperator(prepoperator.TUOperator):
 
-        def __init__(self, config):
+        def __init__(self, config, process_type, build_state):
             self._rand_repl_gen = self._replacement_generator()
 
         @staticmethod


### PR DESCRIPTION
- Some operators may need access to global configuration. Minimally, source and target language, but possibly some training options as well.

- Operators need to know process type (training, inference, postprocess) for correct initialization. For example, in inference, we do not want to initialize target UDs.