### PR TITLE
Only call Consumer.finalize after all files have been processed

### DIFF
--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -332,8 +332,8 @@ class SamplerFileWriter(SamplerConsumer):
 
         yield
 
-        for f in self._files.values():
-            f.close()
+        for file_obj in self._files.values():
+            file_obj.close()
         self._file_summary = None
         self._files = None
 


### PR DESCRIPTION
finalize can trigger vocabulary building and subword learning so it should happen after all files have been processed.

Updating the summary of a single file should happen in the __call__ method instead. The summary is now passed when setting the context for the active file.

This changes also introduces context manager to properly close files, even when exceptions are raised.