### PR TITLE
Store reversed ops as a list

### DIFF
--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -120,7 +120,7 @@ class Pipeline(object):
 
         if self._process_type == ProcessType.POSTPROCESS:
             # Reverse preprocessing operators.
-            self._ops = reversed(self._ops)
+            self._ops = list(reversed(self._ops))
 
             # Reverse start and build states.
             self.start_state, self.build_state = self.build_state, self.start_state


### PR DESCRIPTION
reversed() return an iterator and not a list. However, a list is needed here because _add_op_list calls the append() method.