### PR TITLE
Decouple consumers from the pipeline build state

### DIFF
--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -34,6 +34,9 @@ class SamplerConsumer(Consumer):
         self._num_samples += len(tu_list)
         self._consume(tu_batch)
 
+    def finalize(self, config, summary=None):
+        pass
+
     @abc.abstractmethod
     def _consume(self, tu_batch):
         raise NotImplementedError()

--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -45,6 +45,18 @@ def get_operator_params(config):
     config.pop("op", None)
     return config
 
+def collect_operator_params(global_config, op_name, exit_step=None):
+    """Returns all occurences of an operator in the configuration."""
+    params = []
+    preprocess_config = global_config.get("preprocess")
+    if preprocess_config:
+        for i, operator_config in enumerate(preprocess_config):
+            if exit_step is not None and i > exit_step:
+                break
+            if get_operator_type(operator_config) == op_name:
+                params.append(get_operator_params(operator_config))
+    return params
+
 
 def build_operator(operator_config, global_config, process_type, state):
     """Creates an operator instance from its configuration."""
@@ -301,7 +313,6 @@ class Aligner(Operator):
     def __init__(self, align_config, process_type, build_state):
         self._align_config = align_config
         self._aligner = None
-        build_state['write_alignment'] = self._align_config.get('write_alignment', False)
 
     def _preprocess(self, tu_batch, training=True):
         tu_list, meta_batch = tu_batch


### PR DESCRIPTION
Prior to this change, the pipeline should be built before using the
consumer. It seems more flexible to decouple the two objects. For
example, parallelization may require to build pipelines in separate
processes and the pipeline may not be accessible at this point.

The pipeline build_state was currently used to decide whether
alignments should be saved on disk or not. We could alternatively
directly look in the configuration.

This change also moves the update of "num_samples" in the base class
so that all calls to generate_preprocessed_data return a valid value.