### PR TITLE
Define the file context in the Consumer implementation

### DIFF
--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -301,10 +301,12 @@ class Aligner(Operator):
     def __init__(self, align_config, process_type, build_state):
         self._align_config = align_config
         self._aligner = None
-        build_state['write_alignment'] = self._align_config.get('write_alignment', False)
+        self._write_alignment = self._align_config.get('write_alignment', False)
 
     def _preprocess(self, tu_batch, training=True):
         tu_list, meta_batch = tu_batch
+        if training:
+            meta_batch['write_alignment'] = self._write_alignment
         self._build_aligner()
         tu_list = self._set_aligner(tu_list)
         return tu_list, meta_batch


### PR DESCRIPTION
This change simplifies the Consumer usage by not requiring to set a
file context before passing some TUs. This is especially useful to
allow cross-file parallelization.

The batch metadata contain information about the file where the batch
is coming from, so we can use this information to know where to write
the outputs. When we get a batch from a file we did not see before,
the output files are cleared and then opened in append mode.

Consequently, the flag to write alignments on disk has been moved to
the batch metadata.