### PR TITLE
Require source and target fields in tokenization config

### DIFF
--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -243,8 +243,8 @@ class LengthFilter(Filter):
 class Tokenizer(Operator):
 
     def __init__(self, tok_config, process_type, build_state):
-        self._src_tok_config = tok_config.get("source") or tok_config.get("multi")
-        self._tgt_tok_config = tok_config.get("target") or tok_config.get("multi")
+        self._src_tok_config = tok_config["source"]
+        self._tgt_tok_config = tok_config["target"]
 
         if build_state:
             self._src_tok_config_prev = build_state["src_tok_config"]

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -111,12 +111,11 @@ class TrainingProcessor(Processor):
         opt_source = tok_config.get('source', {}).get(build_option)
         opt_target = tok_config.get('target', {}).get(build_option)
 
-        if not opt_multi and not (opt_source and opt_target):
+        if not opt_multi and not opt_source and not opt_target:
             logger.warning('No \'%s\' option specified, exit without preprocessing.' % build_option)
             return
 
-        if (opt_multi and opt_source) or \
-           (opt_multi and opt_target) :
+        if opt_multi and (opt_source or opt_target):
             raise RuntimeError('Cannot specify \'%s\' for both \'multi\' and either \'source\' or \'target\'.' % build_option)
 
         # Generate preprocessed sentences and feed them to subword learners or to vocabularies.
@@ -132,10 +131,9 @@ class TrainingProcessor(Processor):
             raise RuntimeError('No \'tokenization\' operator in preprocess configuration, cannot build vocabularies.)')
 
         for i, tok_config in enumerate(tok_configs):
-            if ('source' not in tok_config or 'target' not in tok_config) and 'multi' not in tok_config :
-                raise RuntimeError('Each \'tokenization\' operator should contain \
-                                    either both \'source\' and \'target\' fields \
-                                or \'multi\' field.')
+            if 'source' not in tok_config or 'target' not in tok_config:
+                raise RuntimeError('Each \'tokenization\' operator should contain '
+                                   'both \'source\' and \'target\' fields.')
 
             for side in tok_config:
                 build_vocab = tok_config[side].get('build_vocabulary')


### PR DESCRIPTION
To make things simpler, source and target fields should always be
set. 'multi' can be used only to configure shared subword and
vocabulary options.

This change also clarifies in the consumer implementation that multi
and source/target are mutually exclusive.