### PR TITLE
Improve checks for None variables

### DIFF
--- a/nmtwizard/preprocess/loader.py
+++ b/nmtwizard/preprocess/loader.py
@@ -33,11 +33,8 @@ class BasicLoader(Loader):
         self._start_state = start_state
 
     def __call__(self):
-        tu_list = []
-        if self._input:
-            tu_list.append(tu.TranslationUnit(self._input, self._start_state))
+        tu_list = [tu.TranslationUnit(self._input, self._start_state)]
         yield tu_list, {}
-        return
 
 
 class FileLoader(Loader):

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -436,6 +436,19 @@ def test_preprocess_gzip_file(tmpdir):
     assert sampler.count_lines(output_path)[1] == num_lines
 
 
+def test_preprocess_empty_line(tmpdir):
+    processor = InferenceProcessor(config_base)
+    (source, _), _ = processor.process_input("")
+    assert source[0] == []
+
+    input_path = str(tmpdir.join("empty.txt"))
+    with open(input_path, "w") as input_file:
+        input_file.write("\n")
+    output_path, _ = processor.process_file(input_path)
+    with open(output_path) as output_file:
+        assert output_file.readlines() == ["\n"]
+
+
 def test_preprocess_align(tmpdir):
 
     preprocessor = TrainingProcessor(config_base, "", str(tmpdir))


### PR DESCRIPTION
`if not var` can mean `var is None` or `len(var) == 0`. In most cases, it is clearer to explicitly check for None.

This improves support for empty TUs, which can happen especially in inference.