### PR TITLE
Add Token objects in the Tokenization structure

### DIFF
--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -91,21 +91,15 @@ class OpsProfileLogger(Consumer):
 def _ingest_tokens(subword_learner, tu_side):
     if not tu_side.tokens:
         return
-    for part in tu_side.tokens:
+    for part in tu_side.token_objects:
         for token in part:
-            # This method ignores annotations and placeholder tokens.
             subword_learner.ingest_token(token)
 
-def _build_subword_learner(tok_config, result_dir, ref_tok_config=None):
+def _build_subword_learner(tok_config, result_dir):
     subword_config = tok_config.get('build_subword')
     if subword_config is None:
         return {}
-    if ref_tok_config is None:
-        ref_tok_config = tok_config
-    subword_info = tokenizer.make_subword_learner(
-        subword_config,
-        result_dir,
-        tokenizer=tokenizer.build_tokenizer(ref_tok_config))
+    subword_info = tokenizer.make_subword_learner(subword_config, result_dir)
     return subword_info
 
 def _build_vocabulary_counters(config):
@@ -136,8 +130,7 @@ class SubwordLearner(Consumer):
         # ignore them. We assume for a shared subword model that the source and target
         # tokenizers use the same type of annotations, and pass the source tokenization
         # config when building the shared learner.
-        # TODO: clean this up (this can be resolved using the "Token API" of the OpenNMT Tokenizer).
-        shared_subword_info = _build_subword_learner(shared_config, result_dir, source_config)
+        shared_subword_info = _build_subword_learner(shared_config, result_dir)
         if shared_subword_info:
             self._source_subword_info = shared_subword_info
             self._target_subword_info = shared_subword_info

--- a/nmtwizard/preprocess/tokenizer.py
+++ b/nmtwizard/preprocess/tokenizer.py
@@ -3,8 +3,6 @@
 
 import pyonmttok
 
-joiner_marker = "￭"
-
 _ALLOWED_TOKENIZER_ARGS = set([
     "bpe_dropout",
     "bpe_model_path",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 https://github.com/SYSTRAN/storages/archive/221fdea969473f10289f628e173b24c528c287d7.tar.gz
 jsonschema
-pyonmttok>=1.18.5,<2
+pyonmttok>=1.20.0,<2
 requests
 six>=1.13,<2
 systran-align

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -528,30 +528,42 @@ def test_replace_tokens(tmpdir):
                 return new_al_idx
 
 
-            src_tokens = tu.src_tok.tokens if tu.src_tok else None
-            tgt_tokens = tu.tgt_tok.tokens if tu.tgt_tok else None
-
-            src_len = len(src_tokens[0]) if src_tokens else 0
-            tgt_len = len(tgt_tokens[0]) if tgt_tokens else 0
-
-            if src_len and tgt_len:
+            if tu.src_tok.tokens and tu.tgt_tok.tokens:
                 alignment_before = deepcopy(tu.alignment[0])
 
                 joiner_marker = "￭"
 
                 next(self._rand_repl_gen)
+                src_len = len(tu.src_tok.tokens[0])
+                tgt_len = len(tu.tgt_tok.tokens[0])
                 src_replace, tgt_replace = self._rand_repl_gen.send((src_len, tgt_len))
 
                 src_pos, src_num_to_del, src_tok_replace = src_replace
                 tgt_pos, tgt_num_to_del, tgt_tok_replace = tgt_replace
 
-                src_joiner_start, src_joiner_end = joiner_side(src_tokens, src_pos, src_num_to_del)
-                tgt_joiner_start, tgt_joiner_end = joiner_side(tgt_tokens, tgt_pos, tgt_num_to_del)
+                src_joiner_start, src_joiner_end = joiner_side(
+                    tu.src_tok.tokens, src_pos, src_num_to_del)
+                tgt_joiner_start, tgt_joiner_end = joiner_side(
+                    tu.tgt_tok.tokens, tgt_pos, tgt_num_to_del)
 
                 tu.replace_tokens(src_replace, tgt_replace)
 
-                checks_side(src_tokens, src_len, src_pos, src_num_to_del, src_tok_replace, src_joiner_start, src_joiner_end)
-                checks_side(tgt_tokens, tgt_len, tgt_pos, tgt_num_to_del, tgt_tok_replace, tgt_joiner_start, tgt_joiner_end)
+                checks_side(
+                    tu.src_tok.tokens,
+                    src_len,
+                    src_pos,
+                    src_num_to_del,
+                    src_tok_replace,
+                    src_joiner_start,
+                    src_joiner_end)
+                checks_side(
+                    tu.tgt_tok.tokens,
+                    tgt_len,
+                    tgt_pos,
+                    tgt_num_to_del,
+                    tgt_tok_replace,
+                    tgt_joiner_start,
+                    tgt_joiner_end)
 
                 # Check alignment
                 alignment_after = tu.alignment[0]


### PR DESCRIPTION
The Token class makes it easier to manipulate tokens with annotations.

The replace_token method has been updated to use these objects. A side
effect is that it can no longer apply the modification in-place
because it needs to invalidate the other representation by calling the
"tok" setter. The test has been updated to not make the assumptions
that the tokens list is modified in-place.

The performance impact of this change should be small: the Token
objects are always used as an intermediate representation during
tokenization. The memory usage is of course doubled. This should not
be an issue with proper batching of the corpus.