### PR TITLE
Extend base operator class

### DIFF
--- a/nmtwizard/preprocess/operators/alignment.py
+++ b/nmtwizard/preprocess/operators/alignment.py
@@ -17,7 +17,7 @@ class Aligner(prepoperator.Operator):
 
     def _preprocess(self, tu_batch):
         tu_list, meta_batch = tu_batch
-        if self._process_type == prepoperator.ProcessType.TRAINING:
+        if self.process_type == prepoperator.ProcessType.TRAINING:
             meta_batch['write_alignment'] = self._write_alignment
         self._build_aligner()
         tu_list = self._set_aligner(tu_list)

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -500,8 +500,6 @@ def test_release_change_file(tmpdir):
 # Dummy domain classifier operator.
 @prepoperator.register_operator("domain")
 class _DomainClassifier(prepoperator.Operator):
-    def __init__(self, *arg, **kwargs):
-        pass
     def _preprocess(self, tu_batch):
         return tu_batch
 


### PR DESCRIPTION
* Define the base constructor to allow implementing small operators without constructor
* Set name as an attribute in build_operator
* Set process_type as an attribute in build_operator and remove the need to pass it for each call