### PR TITLE
Finalize TU at the end of the pipeline

### DIFF
--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -379,12 +379,12 @@ class BasicWriter(Consumer):
             self.output = tu.tgt_detok
         # Preprocess in inference.
         else:
-            src_tokens = tu.build_preprocessed_tokens("source")
-            tgt_tokens = tu.build_preprocessed_tokens("target")
+            src_tokens = tu.src_tok.tokens
             # target should contain as many parts as source
+            tgt_tokens = tu.tgt_tok.tokens if tu.tgt_tok is not None else [None for _ in src_tokens]
             self.output = (
                 src_tokens,
-                tgt_tokens if tgt_tokens else [None for _ in src_tokens],
+                tgt_tokens,
                 tu.metadata)
 
 
@@ -423,7 +423,7 @@ class FileWriter(Consumer):
                 self._file.write("%s\n" % tu.tgt_detok)
             # Preprocess.
             else:
-                src_tokens = tu.build_preprocessed_tokens("source")
+                src_tokens = tu.src_tok.tokens
                 for part in src_tokens:
                     part = " ".join(part)
                     self._file.write("%s\n" % part)
@@ -472,7 +472,7 @@ class SamplerFileWriter(Consumer):
         # Write lines to file from TUs
         with open(src_path, "a") as src_file, open(tgt_path, "a") as tgt_file:
             for tu in tu_list :
-                src_tokens = tu.build_preprocessed_tokens("source")
+                src_tokens = tu.src_tok.tokens
                 if src_tokens :
                     for part in src_tokens :
                         part = " ".join(part)
@@ -480,7 +480,7 @@ class SamplerFileWriter(Consumer):
                 else:
                     src_file.write("%s\n" % tu.src_detok)
 
-                tgt_tokens = tu.build_preprocessed_tokens("target")
+                tgt_tokens = tu.tgt_tok.tokens
                 if tgt_tokens :
                     for part in tgt_tokens :
                         part = " ".join(part)

--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -193,9 +193,8 @@ class Pipeline(object):
         if ops_profile is not None:
             batch_meta['ops_profile'] = ops_profile
 
-        if self._process_type != ProcessType.POSTPROCESS:
-            for tu in tu_list:
-                tu.synchronize()
+        for tu in tu_list:
+            tu.finalize(self._process_type)
 
         return tu_list, batch_meta
 

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -190,6 +190,7 @@ class TranslationSide(object):
 
     def finalize(self):
         _ = self.tok
+        _ = self.detok
         self.__tokenizer = None
 
     def append(self, other):

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -3,6 +3,7 @@ import itertools
 import pyonmttok
 
 from nmtwizard.logger import get_logger
+from nmtwizard.preprocess import prepoperator
 
 logger = get_logger(__name__)
 
@@ -10,10 +11,10 @@ logger = get_logger(__name__)
 class Tokenization(object):
     """Structure to keep tokenizer and tokens together."""
 
-    def __init__(self, tokenizer, token_objects=None):
+    def __init__(self, tokenizer, token_objects=None, tokens=None):
         self._tokenizer = tokenizer
         self._token_objects = token_objects
-        self._tokens = None  # String tokens are lazily generated.
+        self._tokens = tokens
 
     @property
     def tokenizer(self):
@@ -25,12 +26,6 @@ class Tokenization(object):
 
     @property
     def tokens(self):
-        if self._token_objects is None:
-            return None
-        if self._tokens is None:
-            self._tokens = [
-                self._tokenizer.serialize_tokens(part)[0]
-                for part in self._token_objects]
         return self._tokens
 
 
@@ -125,6 +120,7 @@ class TranslationSide(object):
             self.raw = line.strip()
             self.__detok = self.raw
             self.__tok = None
+            self.__tok_str = None
             self.__tokenizer = tokenizer
         elif isinstance(line, list):
             self.raw = None
@@ -142,7 +138,9 @@ class TranslationSide(object):
                 return Tokenization(self.__tokenizer)
             else:
                 self.__tok = [self.__tokenizer.tokenize(self.__detok, as_token_objects=True)]
-        return Tokenization(self.__tokenizer, list(self.__tok))
+        if self.__tok_str is None:
+            self.__tok_str = [self.__tokenizer.serialize_tokens(part)[0] for part in self.__tok]
+        return Tokenization(self.__tokenizer, list(self.__tok), list(self.__tok_str))
 
     @tok.setter
     def tok(self, tok):
@@ -150,7 +148,10 @@ class TranslationSide(object):
         if tok is not None:
             # Set a new list of tokens and a new tokenizer.
             if tok and tok[0] and not isinstance(tok[0][0], pyonmttok.Token):
+                self.__tok_str = tok
                 tok = [tokenizer.deserialize_tokens(part) for part in tok]
+            else:
+                self.__tok_str = None
             self.__tok = tok
             self.__tokenizer = tokenizer
             self.__detok = None
@@ -161,6 +162,7 @@ class TranslationSide(object):
                     raise RuntimeError('No tokenizer is set, cannot perform detokenization.')
                 self.__detok = self.__tokenizer.detokenize(self.__tok[0]) # TODO : preperly deal with multipart.
             self.__tok = None
+            self.__tok_str = None
             self.__tokenizer = tokenizer
 
     @property
@@ -176,6 +178,7 @@ class TranslationSide(object):
     def detok(self, detok):
         self.__detok = detok
         self.__tok = None
+        self.__tok_str = None
 
     @property
     def output_side(self):
@@ -185,6 +188,34 @@ class TranslationSide(object):
     def output_delimiter(self):
         return self._output_delimiter
 
+    def finalize(self):
+        _ = self.tok
+        self.__tokenizer = None
+
+    def append(self, other):
+        other_token_objects = other.tok.token_objects
+        if other_token_objects is None:
+            if not other.detok:
+                return False
+            self.detok = (
+                self.detok
+                + ((' ' + other.output_delimiter) if other.output_delimiter is not None else '')
+                + ' ' + other.detok)
+        else:
+            if not other_token_objects[0]:
+                return False
+            tok = self.tok
+            tokenizer = tok.tokenizer
+            token_objects = tok.token_objects
+            if token_objects is None:
+                token_objects = [[]]
+            elif len(token_objects) > 1:
+                return False
+            elif token_objects[0] and other.output_delimiter is not None:
+                token_objects[0].append(pyonmttok.Token(other.output_delimiter))
+            token_objects[0].extend(other_token_objects[0])
+            self.tok = (tokenizer, token_objects)
+        return True
 
     def replace_tokens(self, start_idx, tok_num, new_tokens=None, part=0):
 
@@ -215,6 +246,7 @@ class TranslationSide(object):
                     cur_tokens[start_idx:end_idx] = new_tokens
 
             self.__detok = None
+            self.__tok_str = None
         else:
             logger.warning("Cannot replace tokens, no tokenization is set.")
 
@@ -266,11 +298,6 @@ class TranslationUnit(object):
     def num_targets(self):
         return len(self.__target) if self.__target is not None else 0
 
-
-    def synchronize(self):
-        _ = self.src_tok
-        _ = self.tgt_tok
-        self._initialize_alignment()
 
     @property
     def src_tok(self):
@@ -415,45 +442,37 @@ class TranslationUnit(object):
             if key == "main":
                 self._invalidate_alignment()
 
-    def build_preprocessed_tokens(self, side):
-        tok = None
-        if side == "source":
-            tok = self.__source
-        elif side == "target":
-            tok = self.__target
-        else:
-            raise ValueError("Invalid side value when building output: %s" % side)
+    def _finalize_side(self, name, side):
+        main_side = side.get("main")
+        if main_side is None:
+            return
 
-        if tok is not None:
-            main_side = tok.get("main")
-            if main_side is not None:
-                tok = main_side.tok.tokens
-            else:
-                tok = None
-
-        if tok is None or len(tok) > 1:
-            # Main side tokenization doesn't exist OR
-            # Main side tokenization is multipart
-            return tok
-
-        # We suppose here that extra sources and targets are all single-part.
-        # Can be changed/improved later.
-
-        all_translation_sides = [ts for k, ts  in self.__source.items() if k != "main"]
+        # Merge secondary sides into the main side.
+        all_sides = self.__source.items()
         if self.__target is not None:
-            all_translation_sides += [ts for k, ts  in self.__target.items() if k != "main"]
+            all_sides = itertools.chain(all_sides, self.__target.items())
+        sides_to_merge = (ts for k, ts in all_sides if k != "main" and ts.output_side == name)
+        for ts in sides_to_merge:
+            main_side.append(ts)
 
-        for ts in all_translation_sides:
-            if ts.output_side == side:
-                tokens = ts.tok.tokens
-                if not tokens or len(tokens[0]) == 0:
-                    continue
-                if tok[0] and ts.output_delimiter is not None:
-                    # Some previous tokens exist, we need to insert the delimiter.
-                    tok[0].append(ts.output_delimiter)
-                tok[0].extend(tokens[0])
+        # Synchronize the main side and detach the Tokenizer instance.
+        main_side.finalize()
 
-        return tok
+        # Remove secondary sides.
+        for key in list(side.keys()):
+            if key != "main":
+                side.pop(key)
+
+    def finalize(self, process_type):
+        if process_type != prepoperator.ProcessType.POSTPROCESS:
+            # Synchronize alignments and detach the Aligner instance.
+            self._initialize_alignment()
+            if self.__alignment is not None:
+                self.__alignment.aligner = None
+
+            self._finalize_side("source", self.__source)
+            if self.__target is not None:
+                self._finalize_side("target", self.__target)
 
     @property
     def metadata(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 https://github.com/SYSTRAN/storages/archive/221fdea969473f10289f628e173b24c528c287d7.tar.gz
 jsonschema
-pyonmttok>=1.20.0,<2
+pyonmttok>=1.22.0,<2
 requests
 six>=1.13,<2
 systran-align

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 https://github.com/SYSTRAN/storages/archive/221fdea969473f10289f628e173b24c528c287d7.tar.gz
 jsonschema
-pyonmttok>=1.22.0,<2
+pyonmttok>=1.22.1,<2
 requests
 six>=1.13,<2
 systran-align

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -60,7 +60,14 @@ def test_sampler(tmpdir, batch_size, num_threads):
                     ]
                 }
             ]
-        }
+        },
+        "preprocess": [
+            {
+                "op": "tokenization",
+                "source": {"mode": "space"},
+                "target": {"mode": "space"},
+            }
+        ],
     }
 
     preprocessor = TrainingProcessor(config, "", str(tmpdir))


### PR DESCRIPTION
This change is motivated by 2 observations:

* build_preprocess_tokens was not consistently called in
  consumers (e.g. subword, build vocab) so it could create a mismatch.
  This indicates that finalizing the tokens should happen before
  calling the consumers.
* In multi worker preprocessing, we can't return TUs having a
  reference to Tokenizer or Aligner objects. So we need to synchronize
  the fields and detach these instances.

An alternative would be to add an `TU.export()` method which returns a finalized and read-only structure containing the result.