### PR TITLE
Add a mechanism to share operator resources across workers

### DIFF
--- a/nmtwizard/preprocess/operators/alignment.py
+++ b/nmtwizard/preprocess/operators/alignment.py
@@ -10,33 +10,37 @@ class Aligner(prepoperator.Operator):
     def is_applied_for(process_type):
         return process_type == prepoperator.ProcessType.TRAINING
 
-    def __init__(self, align_config, process_type, build_state):
-        self._align_config = align_config
-        self._aligner = None
-        self._write_alignment = self._align_config.get('write_alignment', False)
+    # Alignment models can take several GB in memory so we need to share an Aligner
+    # instance across workers.
+
+    @staticmethod
+    def get_shared_classes():
+        return [systran_align.Aligner]
+
+    @staticmethod
+    def get_shared_builders(config, process_type):
+        forward_probs_path = config.get('forward', {}).get('probs')
+        backward_probs_path = config.get('backward', {}).get('probs')
+        if forward_probs_path is None or backward_probs_path is None:
+            return None
+        if not os.path.isfile(forward_probs_path):
+            raise ValueError("Forward probs file for alignment doesn't exist: %s" % (
+                forward_probs_path))
+        if not os.path.isfile(backward_probs_path):
+            raise ValueError("Backward probs file for alignment doesn't exist: %s" % (
+                backward_probs_path))
+        return {"aligner": (systran_align.Aligner, (forward_probs_path, backward_probs_path))}
+
+    def __init__(self, align_config, process_type, build_state, shared_state=None):
+        self._aligner = shared_state['aligner'] if shared_state else None
+        self._write_alignment = align_config.get('write_alignment', False)
 
     def _preprocess(self, tu_batch):
         tu_list, meta_batch = tu_batch
         if self.process_type == prepoperator.ProcessType.TRAINING:
             meta_batch['write_alignment'] = self._write_alignment
-        self._build_aligner()
         tu_list = self._set_aligner(tu_list)
         return tu_list, meta_batch
-
-
-    def _build_aligner(self):
-        if not self._aligner and self._align_config:
-            # TODO : maybe add monotonic alignment ?
-            forward_probs_path=self._align_config.get('forward', {}).get('probs')
-            backward_probs_path=self._align_config.get('backward', {}).get('probs')
-            if forward_probs_path and backward_probs_path:
-                if not os.path.exists(forward_probs_path) or not os.path.isfile(forward_probs_path):
-                    raise ValueError("Forward probs file for alignment doesn't exist: %s" % forward_probs_path)
-                if not os.path.exists(backward_probs_path) or not os.path.isfile(backward_probs_path):
-                    raise ValueError("Backward probs file for alignment doesn't exist: %s" % backward_probs_path)
-                self._aligner = systran_align.Aligner(forward_probs_path, backward_probs_path)
-            else:
-                self._aligner = None
 
     def _set_aligner(self, tu_list):
         # Set aligner for TUs.

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -324,7 +324,6 @@ class InferenceProcessor(Processor):
 
 class SharedManager(multiprocessing.managers.BaseManager):
     """Custom manager for shared resources with multiprocessing."""
-    pass
 
 
 class SharedState:

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -385,7 +385,7 @@ class SharedState:
             self._manager = SharedManager()
             self._manager.start()
 
-        # Create all new proxy instances.
+        # Create all new shared instances.
         shared_state = collections.defaultdict(dict)
         for i, builders in all_builders.items():
             existing_state = self._all_state[i]

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -2,6 +2,7 @@
 
 import collections
 import multiprocessing
+import multiprocessing.managers
 import os
 
 from nmtwizard import utils
@@ -28,6 +29,10 @@ def _get_num_workers():
     num_cpus = int(os.environ.get('NB_CPU', '1'))
     return num_cpus if num_cpus > 1 else 0  # Run the sequential path if only 1 CPU is available.
 
+def _get_corpus_label(tu_batch):
+    _, batch_meta = tu_batch
+    return batch_meta.get('label') if batch_meta else None
+
 
 class Processor(object):
 
@@ -37,22 +42,23 @@ class Processor(object):
         self._preprocess_exit_step = None
         self._pipeline = None
 
-    def build_pipeline(self, config=None, override_label=None):
+    def build_pipeline(self, config=None, override_label=None, shared_state=None):
         if config is None:
             config = self._config
         return prepoperator.Pipeline(
             config,
             self._pipeline_type,
             preprocess_exit_step=self._preprocess_exit_step,
-            override_label=override_label
+            override_label=override_label,
+            shared_state=shared_state,
         )
 
-    def process_batch(self, tu_batch, options=None):
+    def process_batch(self, tu_batch, options=None, shared_state=None):
         # Lazily create the pipeline so that it is created in each worker process.
-        _, batch_meta = tu_batch
-        override_label = batch_meta.get('label', None) if batch_meta else None
+        override_label = _get_corpus_label(tu_batch)
         if self._pipeline is None or self._pipeline.override_label != override_label:
-            self._pipeline = self.build_pipeline(override_label=override_label)
+            self._pipeline = self.build_pipeline(
+                override_label=override_label, shared_state=shared_state)
         return self._pipeline(tu_batch, options=options)
 
     def process(self,
@@ -63,10 +69,16 @@ class Processor(object):
                 options=None):
         self._preprocess_exit_step = preprocess_exit_step
 
+        shared_state = SharedState(self._pipeline_type, num_workers)
+
         if num_workers == 0:
 
             for tu_batch in loader():
-                tu_batch = self.process_batch(tu_batch, options=options)
+                override_label = _get_corpus_label(tu_batch)
+                tu_batch = self.process_batch(
+                    tu_batch,
+                    options=options,
+                    shared_state=shared_state.get_state(self._config, override_label))
                 consumer(tu_batch)
 
         else:
@@ -80,8 +92,13 @@ class Processor(object):
                 results = collections.deque()
 
                 for tu_batch in loader():
+                    override_label = _get_corpus_label(tu_batch)
+
                     # Push the batch in the process queue and get a handle on the result.
-                    results.append(pool.apply_async(self.process_batch, (tu_batch, options)))
+                    results.append(pool.apply_async(self.process_batch, (
+                        tu_batch,
+                        options,
+                        shared_state.get_state(self._config, override_label))))
 
                     # Limit the queue max size to avoid loading too many batches in advance.
                     if len(results) == 2 * num_workers:
@@ -302,3 +319,68 @@ class InferenceProcessor(Processor):
             if self._postprocess:
                 return output_file
             return output_file, file_consumer.metadata
+
+
+
+class SharedManager(multiprocessing.managers.BaseManager):
+    """Custom manager for shared resources with multiprocessing."""
+    pass
+
+
+class SharedState:
+    """A class collecting shared objects created by operators."""
+
+    def __init__(self, process_type, num_workers=0):
+        self._all_state = collections.defaultdict(dict)
+        self._process_type = process_type
+        self._num_workers = num_workers
+        self._manager = None
+
+    def get_state(self, config, override_label=None):
+        """Returns the shared state for this configuration and corpus label."""
+        preprocess_config = config.get("preprocess")
+        if not preprocess_config:
+            return {}
+
+        all_builders = {}
+        for i, operator_config in enumerate(preprocess_config):
+            # Get operator class and config.
+            operator_type = prepoperator.get_operator_type(operator_config)
+            operator_cls = prepoperator.get_operator_class(operator_type)
+            if not operator_cls.is_applied_for(self._process_type):
+                continue
+            operator_params = prepoperator.get_operator_params(
+                operator_config, override_label=override_label)
+            if operator_params.get("disabled", False):
+                continue
+
+            # On initialization, register all classes that can be shared by this operator.
+            if self._num_workers > 0 and self._manager is None:
+                shared_classes = operator_cls.get_shared_classes()
+                if shared_classes is not None:
+                    for cls in operator_cls.get_shared_classes():
+                        SharedManager.register(cls.__name__, cls)
+
+            # Save how to build shared classes for this operator.
+            builders = operator_cls.get_shared_builders(operator_params, self._process_type)
+            if builders:
+                all_builders[i] = builders
+
+        if self._num_workers > 0 and self._manager is None:
+            self._manager = SharedManager()
+            self._manager.start()
+
+        # Create all new proxy instances.
+        shared_state = collections.defaultdict(dict)
+        for i, builders in all_builders.items():
+            existing_state = self._all_state[i]
+            for name, (cls, args) in builders.items():
+                key = "%s_%s" % (cls.__name__, str(args))
+                if key not in existing_state:
+                    if self._manager is not None:
+                        shared_instance = getattr(self._manager, cls.__name__)(*args)
+                    else:
+                        shared_instance = cls(*args)
+                    existing_state[key] = shared_instance
+                shared_state[i].update({name: existing_state[key]})
+        return shared_state


### PR DESCRIPTION
Operators can declare resources that will be shared across
workers. This is needed for operators using very large
resources (e.g. alignment models).

We use the Manager concept from the multiprocessing module to build a
shared instance and pass a proxy instance to each worker. The proxy
instance can be used like the original object but the computation will
happen in a separate process.