### PR TITLE
Fix cloud translation frameworks

### DIFF
--- a/nmtwizard/cloud_translation_framework.py
+++ b/nmtwizard/cloud_translation_framework.py
@@ -76,8 +76,20 @@ class CloudTranslationFramework(Framework):
         return [[TranslationOutput(translation)] for translation in self.translate_batch(
             inputs, model_info['source'], model_info['target'])]
 
-    def _preprocess_input(self, state, input):
-        return input
+    def _preprocess_input(self, source, target, config):
+        return source, target
 
-    def _postprocess_output(self, state, output):
-        return output
+    def _postprocess_output(self, source, target, config):
+        return target[0]
+
+    def _preprocess_file(self, source_file):
+        return source_file, None
+
+    def _postprocess_file(self, source_file, target_file, metadata=None):
+        return target_file
+
+    def _set_preprocessor(self, config, train=True):
+        pass
+
+    def _set_postprocessor(self, config):
+        pass

--- a/test/test_cloud_translation_framework.py
+++ b/test/test_cloud_translation_framework.py
@@ -74,7 +74,6 @@ def test_serve_cloud_translation_framework():
         framework._preprocess_input,
         functools.partial(framework.forward_request, service_info),
         framework._postprocess_output)
-    _, service_info = framework.serve(config, None)
     assert result["tgt"][0][0]["text"] == "olleH"
 
 @pytest.mark.skipif(


### PR DESCRIPTION
These frameworks should skip all preprocessing and postprocessing.

The tests have been updated to better verify that these frameworks are
actually working for translation and serving in the final image.