### PR TITLE
Remove inference process methods from the Framework

### DIFF
--- a/nmtwizard/cloud_translation_framework.py
+++ b/nmtwizard/cloud_translation_framework.py
@@ -76,20 +76,8 @@ class CloudTranslationFramework(Framework):
         return [[TranslationOutput(translation)] for translation in self.translate_batch(
             inputs, model_info['source'], model_info['target'])]
 
-    def _preprocess_input(self, source, target, config):
-        return source, target
+    def _get_preprocessor(self, config, train=True):
+        return None
 
-    def _postprocess_output(self, source, target, config):
-        return target[0]
-
-    def _preprocess_file(self, source_file):
-        return source_file, None
-
-    def _postprocess_file(self, source_file, target_file, metadata=None):
-        return target_file
-
-    def _set_preprocessor(self, config, train=True):
-        pass
-
-    def _set_postprocessor(self, config):
-        pass
+    def _get_postprocessor(self, config):
+        return None

--- a/test/test_cloud_translation_framework.py
+++ b/test/test_cloud_translation_framework.py
@@ -71,9 +71,7 @@ def test_serve_cloud_translation_framework():
     request = {"src": [{"text": "Hello"}]}
     result = serving.run_request(
         request,
-        framework._preprocess_input,
-        functools.partial(framework.forward_request, service_info),
-        framework._postprocess_output)
+        functools.partial(framework.forward_request, service_info))
     assert result["tgt"][0][0]["text"] == "olleH"
 
 @pytest.mark.skipif(

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1122,9 +1122,9 @@ def test_serve(tmpdir):
 
     result = run_request(
         request,
-        framework._preprocess_input,
         functools.partial(framework.forward_request, model_info),
-        framework._postprocess_output,
+        preprocessor=framework._get_preprocessor(config_base, train=False),
+        postprocessor=framework._get_postprocessor(config_base),
         config=config_base)
 
     # Dummy translation does "target + reversed(source)".


### PR DESCRIPTION
In most cases, it is easier and safer to directly call a method of a
Processor instance.

The Processor.process_input is updated to rebuild the pipeline if the
example has its own configuration (V1 mode). A future PR will disable
this rebuild for V2 configuration and only accepts options.

The process_input method also needs to be thread-safe, as the
inference server is starting a new thread on each request.