### PR TITLE
Reduce preprocessing memory usage

### DIFF
--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -21,13 +21,12 @@ class Consumer(object):
     def num_samples(self):
         return self._num_samples
 
-    def __call__(self, tu_batch):
-        tu_list, _ = tu_batch
-        self._num_samples += len(tu_list)
-        self._consume(tu_batch)
+    def __call__(self, outputs):
+        self._num_samples += len(outputs[0])
+        self._consume(outputs)
 
     @abc.abstractmethod
-    def _consume(self, tu_batch):
+    def _consume(self, outputs):
         raise NotImplementedError()
 
     def finalize(self):
@@ -46,9 +45,9 @@ class MultiConsumer(Consumer):
     def add(self, consumer):
         self._consumers.append(consumer)
 
-    def _consume(self, tu_batch):
+    def _consume(self, outputs):
         for consumer in self._consumers:
-            consumer(tu_batch)
+            consumer(outputs)
 
     def finalize(self):
         for consumer in self._consumers:
@@ -62,8 +61,8 @@ class OpsProfileLogger(Consumer):
         super().__init__()
         self._global_profile = collections.defaultdict(float)
 
-    def _consume(self, tu_batch):
-        _, batch_meta = tu_batch
+    def _consume(self, outputs):
+        _, batch_meta = outputs
         profile = batch_meta.get('ops_profile')
         if not profile:
             return
@@ -95,8 +94,8 @@ class FilterSummaryLogger(Consumer):
         super().__init__()
         self._summary = collections.defaultdict(int)
 
-    def _consume(self, tu_batch):
-        _, batch_meta = tu_batch
+    def _consume(self, outputs):
+        _, batch_meta = outputs
         summary = batch_meta.get("filter_summary")
         if not summary:
             return
@@ -171,18 +170,17 @@ class SubwordLearner(Consumer):
             self._target_subword_info = _build_subword_learner(target_config, result_dir)
 
 
-    def _consume(self, tu_batch):
+    def _consume(self, outputs):
         source_learner = self._source_subword_info.get('learner')
         target_learner = self._target_subword_info.get('learner')
         if source_learner is None and target_learner is None:
             return
 
-        tu_list, _ = tu_batch
-        for tu in tu_list :
+        for output in outputs[0]:
             if source_learner is not None:
-                _ingest_tokens(source_learner, tu.src)
+                _ingest_tokens(source_learner, output.src)
             if target_learner is not None:
-                _ingest_tokens(target_learner, tu.tgt)
+                _ingest_tokens(target_learner, output.tgt)
 
 
     def finalize(self):
@@ -247,17 +245,16 @@ class VocabularyBuilder(Consumer):
             self._target_counters = _build_vocabulary_counters(target_config)
 
 
-    def _consume(self, tu_batch):
+    def _consume(self, outputs):
         if not self._source_counters and not self._target_counters:
             return
 
-        tu_list, _ = tu_batch
         # TODO : remove value for placeholders
-        for tu in tu_list :
-            for token in itertools.chain.from_iterable(tu.src):
+        for output in outputs[0]:
+            for token in itertools.chain.from_iterable(output.src):
                 self._source_counters['tokens'][token] += 1
                 self._source_counters['total'] += 1
-            for token in itertools.chain.from_iterable(tu.tgt):
+            for token in itertools.chain.from_iterable(output.tgt):
                 self._target_counters['tokens'][token] += 1
                 self._target_counters['total'] += 1
 
@@ -388,19 +385,18 @@ class FileWriter(Consumer):
         self._file = None
 
 
-    def _consume(self, tu_batch):
-        tu_list, _ = tu_batch
+    def _consume(self, outputs):
         # Write lines to files from TUs
-        for tu in tu_list :
+        for output in outputs[0]:
             # Postprocess.
             if self._postprocess:
-                self._file.write("%s\n" % tu)
+                self._file.write("%s\n" % output)
             # Preprocess.
             else:
-                for part in tu.src:
+                for part in output.src:
                     part = " ".join(part)
                     self._file.write("%s\n" % part)
-                self.metadata.append(tu.metadata)
+                self.metadata.append(output.metadata)
 
 
 class SamplerFileWriter(Consumer):
@@ -416,8 +412,8 @@ class SamplerFileWriter(Consumer):
         self._tgt_suffix = config['target']
 
 
-    def _consume(self, tu_batch):
-        tu_list, meta = tu_batch
+    def _consume(self, outputs):
+        outputs, meta = outputs
         if 'tokens_to_add' in meta:
             if 'source' in meta['tokens_to_add']:
                 self._tokens_to_add['source'].update(meta['tokens_to_add']['source'])
@@ -440,31 +436,31 @@ class SamplerFileWriter(Consumer):
             if write_alignment:
                 open(align_path, "w").close()
 
-        file_summary["linefiltered"] += len(tu_list)
+        file_summary["linefiltered"] += len(outputs)
 
         # Write lines to file from TUs
         with open(src_path, "a") as src_file, open(tgt_path, "a") as tgt_file:
-            for tu in tu_list :
-                src_tokens = tu.src
+            for output in outputs:
+                src_tokens = output.src
                 if isinstance(src_tokens, list):
                     for part in src_tokens :
                         part = " ".join(part)
                         src_file.write("%s\n" % part)
                 else:
-                    src_file.write("%s\n" % tu.src)
+                    src_file.write("%s\n" % output.src)
 
-                tgt_tokens = tu.tgt
+                tgt_tokens = output.tgt
                 if isinstance(tgt_tokens, list):
                     for part in tgt_tokens :
                         part = " ".join(part)
                         tgt_file.write("%s\n" % part)
                 else:
-                    tgt_file.write("%s\n" % tu.tgt)
+                    tgt_file.write("%s\n" % output.tgt)
 
         if write_alignment:
             with open(align_path, "a") as align_file:
-                for tu in tu_list:
-                    alignment = tu.alignment
+                for output in outputs:
+                    alignment = output.alignment
                     if alignment :
                         for part in alignment:
                             part = " ".join(sorted("%s-%s" % tup for tup in part))

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -67,8 +67,8 @@ class Processor(object):
             self._pipeline = self.build_pipeline(
                 override_label=override_label, shared_state=shared_state)
         tu_list, batch_meta = self._pipeline(tu_batch, options=options)
-        tu_list = [tu.export(self._pipeline_type) for tu in tu_list]
-        return tu_list, batch_meta
+        outputs = [tu.export(self._pipeline_type) for tu in tu_list]
+        return outputs, batch_meta
 
     def process(self,
                 loader,
@@ -83,11 +83,11 @@ class Processor(object):
 
             for tu_batch in loader():
                 override_label = _get_corpus_label(tu_batch)
-                tu_batch = self.process_batch(
+                outputs = self.process_batch(
                     tu_batch,
                     options=options,
                     shared_state=self._get_shared_state(shared_state, override_label))
-                consumer(tu_batch)
+                consumer(outputs)
 
         else:
 

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -66,7 +66,9 @@ class Processor(object):
         if self._pipeline is None or self._pipeline.override_label != override_label:
             self._pipeline = self.build_pipeline(
                 override_label=override_label, shared_state=shared_state)
-        return self._pipeline(tu_batch, options=options)
+        tu_list, batch_meta = self._pipeline(tu_batch, options=options)
+        tu_list = [tu.export(self._pipeline_type) for tu in tu_list]
+        return tu_list, batch_meta
 
     def process(self,
                 loader,


### PR DESCRIPTION
The preprocessing was using a lot of memory, especially when using
multiple workers. It is greatly improved after the following changes:

* Lazily generate token objects and do not store them in the TU
* Export process result in a smaller structure than the
  TranslationUnit class to minimize the serialization cost in multi
  worker preprocessing.
* Remove raw attribute (we can add it back in the future if there is a
  use).