### PR TITLE
Fixes vocabulary management

### DIFF
--- a/frameworks/opennmt_py/entrypoint.py
+++ b/frameworks/opennmt_py/entrypoint.py
@@ -119,11 +119,11 @@ class OpenNMTPYFramework(Framework):
 
     def _map_vocab_entry(self, index, token, vocab):
         if index == 0:
-            vocab.write(b"<unk>\n")
-            vocab.write(b"<blank>\n")
-            vocab.write(b"<s>\n")
-            vocab.write(b"</s>\n")
-        vocab.write(b"%s\n" % token)
+            vocab.write("<unk>\n")
+            vocab.write("<blank>\n")
+            vocab.write("<s>\n")
+            vocab.write("</s>\n")
+        vocab.write("%s\n" % token)
 
 
 def _trans_options(config, gpuid):

--- a/frameworks/opennmt_tf/entrypoint.py
+++ b/frameworks/opennmt_tf/entrypoint.py
@@ -108,10 +108,10 @@ class OpenNMTTFFramework(Framework):
 
     def _map_vocab_entry(self, index, token, vocab):
         if index == 0:
-            vocab.write(b'<blank>\n')
-            vocab.write(b'<s>\n')
-            vocab.write(b'</s>\n')
-        vocab.write(b'%s\n' % token)
+            vocab.write('<blank>\n')
+            vocab.write('<s>\n')
+            vocab.write('</s>\n')
+        vocab.write('%s\n' % token)
 
     def _build_runner(self,
                       config,

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -19,6 +19,7 @@ from nmtwizard import config as config_util
 from nmtwizard import data as data_util
 from nmtwizard import serving
 from nmtwizard.preprocess import preprocess
+from nmtwizard.preprocess import tokenizer
 from nmtwizard import utility
 
 
@@ -927,16 +928,9 @@ class Framework(utility.Utility):
         if basename is None:
             basename = os.path.basename(vocab_file)
         converted_vocab_file = os.path.join(self._data_dir, basename)
-        with open(vocab_file, 'rb') as vocab, open(converted_vocab_file, 'wb') as converted_vocab:
-            header = True
-            index = 0
-            for line in vocab:
-                if header and line.startswith(b'#'):
-                    continue
-                header = False
-                token = line.strip().split()[0]
+        with open(converted_vocab_file, 'wb') as converted_vocab:
+            for index, token in enumerate(tokenizer.vocabulary_iterator(vocab_file)):
                 self._map_vocab_entry(index, token, converted_vocab)
-                index += 1
         return converted_vocab_file
 
     def _build_data(self, config):

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -928,7 +928,7 @@ class Framework(utility.Utility):
         if basename is None:
             basename = os.path.basename(vocab_file)
         converted_vocab_file = os.path.join(self._data_dir, basename)
-        with open(converted_vocab_file, 'wb') as converted_vocab:
+        with open(converted_vocab_file, 'w') as converted_vocab:
             for index, token in enumerate(tokenizer.vocabulary_iterator(vocab_file)):
                 self._map_vocab_entry(index, token, converted_vocab)
         return converted_vocab_file

--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -310,17 +310,11 @@ class VocabularyBuilder(Consumer):
                              else None
 
             if vocab_to_merge and os.path.isfile(vocab_to_merge):
-                with open(vocab_to_merge, 'r') as f:
-                    header = True
-                    for l in f:
-                        if header and l[0] == '#':
-                            continue
-                        header = False
-                        w = l.strip().split(' ')[0]
-                        if w :
-                            # Set heaviest frequency on tokens from vocabulary to merge.
-                            vocabulary[w] = float("inf")
-                            added_size += 1
+                for w in tokenizer.vocabulary_iterator(vocab_to_merge):
+                    if w :
+                        # Set heaviest frequency on tokens from vocabulary to merge.
+                        vocabulary[w] = float("inf")
+                        added_size += 1
 
             # Add extra tokens from a list.
             vocab_to_add = tok_config[side]['build_vocabulary']['add'] \

--- a/nmtwizard/preprocess/tokenizer.py
+++ b/nmtwizard/preprocess/tokenizer.py
@@ -64,15 +64,31 @@ def make_subword_learner(subword_config, subword_dir, tokenizer=None):
         "size": vocab_size
     }
 
+def vocabulary_iterator(vocabulary_path):
+    """Iterates over each token included in the vocabulary file."""
+    with open(vocabulary_path) as vocabulary_file:
+        header = True
+        for line in vocabulary_file:
+            # The vocabulary file might start with some comments prefixed with '#'.
+            if header and line[0] == '#':
+                continue
+            header = False
+            line = line.rstrip('\n\r')
+            fields = line.split(' ')
+            if len(fields) == 1:
+                # No frequency value, the line is just the token.
+                yield fields[0]
+            else:
+                # The code below checks the last field is a frequency and not a part of
+                # a badly formatted token.
+                try:
+                    float(fields[-1])
+                    fields.pop()
+                except ValueError:
+                    pass
+                yield ' '.join(fields)
+
 def load_vocabulary(vocabulary_path):
     if vocabulary_path and isinstance(vocabulary_path, str):
-        vocabulary = []
-        header = True
-        with open(vocabulary_path) as vocabfile:
-            for line in vocabfile:
-                if header and line.startswith('#'):
-                    continue
-                header = False
-                vocabulary.append(line.strip())
-            return set(vocabulary)
+        return set(vocabulary_iterator(vocabulary_path))
     return vocabulary_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 https://github.com/SYSTRAN/storages/archive/745f6f6e7e890c6c06559bcdd98fd51a5fb67c9c.tar.gz
 jsonschema
-pyonmttok>=1.22.1,<2
+pyonmttok>=1.22.2,<2
 requests
 six>=1.13,<2
 systran-align

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -64,7 +64,7 @@ class _TestFramework(Framework):
 
     def _map_vocab_entry(self, index, token, converted_vocab):
         converted_vocab.write(token)
-        converted_vocab.write(b"\n")
+        converted_vocab.write("\n")
 
     def train(self, *args, **kwargs):
         pass

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -73,7 +73,8 @@ def test_tokenization_with_vocabulary_restriction(tmpdir):
 
     vocab_path = str(tmpdir.join("vocab.txt"))
     with open(vocab_path, "w") as vocab_file:
-        vocab_file.write("▁Wor\n")
+        vocab_file.write("# Comment\n")
+        vocab_file.write("▁Wor 0.0224656\n")
     config.update({
         "vocabulary": {
             "source": {

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -1,0 +1,18 @@
+import pytest
+
+from nmtwizard.preprocess import tokenizer
+
+def test_vocabulary_iterator(tmpdir):
+    vocab_path = str(tmpdir.join('vocab.txt'))
+    with open(vocab_path, 'w') as vocab_file:
+        vocab_file.write('# Comment 1\n')
+        vocab_file.write('# Comment 2\n')
+        vocab_file.write('\n')
+        vocab_file.write('hello\n')
+        vocab_file.write('world 42\n')
+        vocab_file.write('toto 0.0224656\n')
+        vocab_file.write('titi 2.8989e-08\n')
+        vocab_file.write('hello world\n')  # Bad token with a space.
+
+    tokens = list(tokenizer.vocabulary_iterator(vocab_path))
+    assert tokens == ['', 'hello', 'world', 'toto', 'titi', 'hello world']


### PR DESCRIPTION
Different functions had different ways of parsing the vocabulary file,
which could cause inconsistencies. The parsing has been moved to
the tokenizer.vocabulary_iterator function and made more robust.

This PR also fixes the vocabulary format that is passed to the OpenNMT
Tokenizer. It does not accept header lines and float frequencies.