### PR TITLE
Correctly set the target type during inference

### DIFF
--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -13,7 +13,6 @@ from nmtwizard.preprocess import prepoperator
 from nmtwizard.preprocess import sampler
 from nmtwizard.preprocess import tokenizer
 from nmtwizard.preprocess.tu import TranslationUnit
-from nmtwizard.serving import TargetType
 
 logger = get_logger(__name__)
 
@@ -282,7 +281,7 @@ class InferenceProcessor(Processor):
     def process_input(self,
                       source,
                       target=None,
-                      target_type=None,
+                      target_name=None,
                       metadata=None,
                       config=None,
                       options=None):
@@ -293,7 +292,7 @@ class InferenceProcessor(Processor):
             list of tokens.
           target: In preprocess, a string. In postprocess, a (possibly multipart)
             list of tokens.
-          target_type: The type of the target that is passed during inference.
+          target_name: The name of the target that is passed during inference.
           metadata: Additional metadata of the input.
           config: The configuration for this example.
           options: A dictionary with operators options.
@@ -320,13 +319,9 @@ class InferenceProcessor(Processor):
         )
 
         if target is not None:
-            if target_type == TargetType.FUZZY:
-                name = 'fuzzy'
-            else:
-                name = 'main'
             tu.add_target(
                 target,
-                name,
+                name=target_name,
                 tokenizer=self._pipeline.start_state.get('tgt_tokenizer'))
 
         tu_batch = ([tu], {})

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -321,9 +321,9 @@ class InferenceProcessor(Processor):
 
         if target is not None:
             if target_type == TargetType.FUZZY:
-                name = "fuzzy"
+                name = 'fuzzy'
             else:
-                name = "main"
+                name = 'main'
             tu.add_target(
                 target,
                 name,

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -267,10 +267,12 @@ class TranslationUnit(object):
 
     def add_source(self,
                    source,
-                   name,
+                   name=None,
                    tokenizer=None,
                    output_side="source",
                    output_delimiter=None):
+        if name is None:
+            name = "main"
         ts = TranslationSide(source, output_side, tokenizer=tokenizer, output_delimiter=output_delimiter)
         if self.__source is not None:
             if name in self.__source:
@@ -281,10 +283,12 @@ class TranslationUnit(object):
 
     def add_target(self,
                    target,
-                   name,
+                   name=None,
                    tokenizer=None,
                    output_side="target",
                    output_delimiter=None):
+        if name is None:
+            name = "main"
         ts = TranslationSide(target, output_side, tokenizer=tokenizer, output_delimiter=output_delimiter)
         if self.__target is not None:
             if name in self.__target:

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -112,8 +112,8 @@ class Alignment(object):
 class TranslationSide(object):
 
     def __init__(self, line, output_side, output_delimiter=None, tokenizer=None):
-        self._output_side = output_side
-        self._output_delimiter = output_delimiter
+        self.output_side = output_side
+        self.output_delimiter = output_delimiter
         if isinstance(line, bytes):
             line = line.decode("utf-8")  # Ensure Unicode string.
         if isinstance(line, str):
@@ -179,14 +179,6 @@ class TranslationSide(object):
         self.__detok = detok
         self.__tok = None
         self.__tok_str = None
-
-    @property
-    def output_side(self):
-        return self._output_side
-
-    @property
-    def output_delimiter(self):
-        return self._output_delimiter
 
     def finalize(self):
         _ = self.tok
@@ -273,7 +265,12 @@ class TranslationUnit(object):
             if alignment is not None:
                 self.__alignment = Alignment(alignments=alignment)
 
-    def add_source(self, source, output_side, name, tokenizer=None, output_delimiter=None):
+    def add_source(self,
+                   source,
+                   name,
+                   tokenizer=None,
+                   output_side="source",
+                   output_delimiter=None):
         ts = TranslationSide(source, output_side, tokenizer=tokenizer, output_delimiter=output_delimiter)
         if self.__source is not None:
             if name in self.__source:
@@ -282,7 +279,12 @@ class TranslationUnit(object):
         else:
             self.__source = {name:ts}
 
-    def add_target(self, target, output_side, name, tokenizer=None, output_delimiter=None):
+    def add_target(self,
+                   target,
+                   name,
+                   tokenizer=None,
+                   output_side="target",
+                   output_delimiter=None):
         ts = TranslationSide(target, output_side, tokenizer=tokenizer, output_delimiter=output_delimiter)
         if self.__target is not None:
             if name in self.__target:
@@ -298,6 +300,17 @@ class TranslationUnit(object):
     @property
     def num_targets(self):
         return len(self.__target) if self.__target is not None else 0
+
+    def has_source(self, name="main"):
+        return name in self.__source
+
+    def has_target(self, name="main"):
+        return self.__target is not None and name in self.__target
+
+    def set_target_output(self, name, side, delimiter):
+        target = self.__target[name]
+        target.output_side = side
+        target.output_delimiter = delimiter
 
 
     @property

--- a/nmtwizard/serving.py
+++ b/nmtwizard/serving.py
@@ -25,6 +25,10 @@ class TranslationOutput(object):
         self.score = score
         self.attention = attention
 
+class TargetType:
+    PREFIX = 0
+    FUZZY = 0
+
 class TranslationExample(
         collections.namedtuple("TranslationExample",
                                (
@@ -282,16 +286,13 @@ def preprocess_example(preprocessor, index, raw_example, config=None):
         raise ValueError("Using both a target prefix and a fuzzy target is currently unsupported")
     if target_prefix is not None:
         target_text = target_prefix
-        target_type = "prefix"
+        target_type = TargetType.PREFIX
     elif target_fuzzy is not None:
         target_text = target_fuzzy
-        target_type = "fuzzy"
+        target_type = TargetType.FUZZY
     else:
         target_text = None
         target_type = None
-    if target_type is not None:
-        config = config.copy() if config is not None else {}
-        config["target_type"] = target_type
 
     if preprocessor is None:
         source_tokens = source_text
@@ -299,7 +300,7 @@ def preprocess_example(preprocessor, index, raw_example, config=None):
         metadata = None
     else:
         source_tokens, target_tokens, metadata = preprocessor.process_input(
-            source_text, target=target_text, config=config)
+            source_text, target=target_text, target_type=target_type, config=config)
 
     # Move to the general multiparts representation.
     if not source_tokens or not isinstance(source_tokens[0], list):

--- a/nmtwizard/serving.py
+++ b/nmtwizard/serving.py
@@ -27,7 +27,7 @@ class TranslationOutput(object):
 
 class TargetType:
     PREFIX = 0
-    FUZZY = 0
+    FUZZY = 1
 
 class TranslationExample(
         collections.namedtuple("TranslationExample",

--- a/nmtwizard/serving.py
+++ b/nmtwizard/serving.py
@@ -25,10 +25,6 @@ class TranslationOutput(object):
         self.score = score
         self.attention = attention
 
-class TargetType:
-    PREFIX = 0
-    FUZZY = 1
-
 class TranslationExample(
         collections.namedtuple("TranslationExample",
                                (
@@ -284,15 +280,14 @@ def preprocess_example(preprocessor, index, raw_example, config=None):
     target_fuzzy = raw_example.get('fuzzy')
     if target_prefix is not None and target_fuzzy is not None:
         raise ValueError("Using both a target prefix and a fuzzy target is currently unsupported")
+
+    target_text = None
+    target_name = None
     if target_prefix is not None:
         target_text = target_prefix
-        target_type = TargetType.PREFIX
     elif target_fuzzy is not None:
         target_text = target_fuzzy
-        target_type = TargetType.FUZZY
-    else:
-        target_text = None
-        target_type = None
+        target_name = "fuzzy"
 
     if preprocessor is None:
         source_tokens = source_text
@@ -300,7 +295,7 @@ def preprocess_example(preprocessor, index, raw_example, config=None):
         metadata = None
     else:
         source_tokens, target_tokens, metadata = preprocessor.process_input(
-            source_text, target=target_text, target_type=target_type, config=config)
+            source_text, target=target_text, target_name=target_name, config=config)
 
     # Move to the general multiparts representation.
     if not source_tokens or not isinstance(source_tokens[0], list):

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -541,7 +541,7 @@ def test_postprocess_multipart_batch_loader(tmpdir):
     target = [["Bonjour"], ["monde"]]
     metadata = [None, None]
 
-    target = processor.process_input(source, target, metadata)
+    target = processor.process_input(source, target, metadata=metadata)
     assert target == "Bonjour monde"
 
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -703,7 +703,9 @@ def test_extra_target(tmpdir):
             return process_type != prepoperator.ProcessType.POSTPROCESS
 
         def _preprocess_tu(self, tu, training):
-            tu.add_target("Das ist ein neues Ziel.", "source", name="extra", output_delimiter="｟delimiter_token｠")
+            tu.add_target("Das ist ein neues Ziel.", "extra")
+            assert tu.has_target("extra")
+            tu.set_target_output("extra", side="source", delimiter="｟delimiter_token｠")
             return [tu]
 
     config_extra_target = deepcopy(config_base)

--- a/test/test_serving.py
+++ b/test/test_serving.py
@@ -251,11 +251,11 @@ def test_run_request():
     assert serving.run_request({"src": []}, None) == {"tgt": []}
 
     class Preprocessor:
-        def process_input(self, source, target=None, config=None, **kwargs):
+        def process_input(self, source, target=None, target_type=None, config=None, **kwargs):
             sep = config["separator"]
             source = source.split(sep)
             if target is not None:
-                assert config.get("target_type") is not None
+                assert target_type is not None
                 target = target.split(sep)
             return source, target, None
 

--- a/test/test_serving.py
+++ b/test/test_serving.py
@@ -251,11 +251,10 @@ def test_run_request():
     assert serving.run_request({"src": []}, None) == {"tgt": []}
 
     class Preprocessor:
-        def process_input(self, source, target=None, target_type=None, config=None, **kwargs):
+        def process_input(self, source, target=None, config=None, **kwargs):
             sep = config["separator"]
             source = source.split(sep)
             if target is not None:
-                assert target_type is not None
                 target = target.split(sep)
             return source, target, None
 


### PR DESCRIPTION
During inference, the request can contain a prefix target or a fuzzy
target. So when building the TU object the target name should be set
accordingly.

(The V1 operator should be updated since the target type is not longer
declared in the configuration but in the TU itself.)