### PR TITLE
Remove support for training on multiple files

### DIFF
--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -146,7 +146,6 @@ class TrainingProcessor(Processor):
 
         num_samples = None
         summary = None
-        metadata = None
 
         # If some sampling OR preprocessing is applied, change result directory.
         if 'data' in self._config or 'preprocess' in self._config:
@@ -159,7 +158,7 @@ class TrainingProcessor(Processor):
             logger.info('Generating data to %s', result_dir)
 
             # Sample files and write information to a special file structure.
-            all_files, summary, metadata = sampler.sample(self._config, data_path)
+            all_files, summary = sampler.sample(self._config, data_path)
             batch_size = self._config.get('data', {}).get('batch_size', 100000)
             sampler_loader = loader.SamplerFilesLoader(all_files, batch_size)
             sampler_consumer = consumer.MultiConsumer([
@@ -187,7 +186,7 @@ class TrainingProcessor(Processor):
             num_samples = sampler_consumer.num_samples
             data_path = result_dir
 
-        return data_path, train_dir, num_samples, summary, metadata
+        return data_path, train_dir, num_samples, summary
 
 
     def _generate_models(self, tokenization_step, option):

--- a/nmtwizard/preprocess/sampler.py
+++ b/nmtwizard/preprocess/sampler.py
@@ -262,7 +262,6 @@ def sample(config, source_dir):
 
     # Calculate the number of lines to keep using weights and lines_counts, select lines randomly.
     distribute = max(0, gsample - reserved_sample)
-    metadata = {}
     summary = {}
     leftover = 0.0
     for f in all_files.values():
@@ -294,8 +293,6 @@ def sample(config, source_dir):
                 if 'annotations' in f.files:
                     summary[f.base_name]['annotations'] = list(f.files['annotations'].keys())
 
-                metadata[f.base_name] = label
-
         _select_lines(f)
 
-    return all_files.values(), summary, metadata
+    return all_files.values(), summary

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -216,9 +216,9 @@ class ReplaceVocabChecker(_TestFramework):
 
     def _generate_training_data(self, config):
         outputs = list(super(ReplaceVocabChecker, self)._generate_training_data(config))
-        if not outputs[-2]:
-            outputs[-2] = {}
-        outputs[-2]["tokens_to_add"] = dict(
+        if not outputs[-1]:
+            outputs[-1] = {}
+        outputs[-1]["tokens_to_add"] = dict(
             source=self.src_tokens_to_add, target=self.tgt_tokens_to_add)
         return tuple(outputs)
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -74,7 +74,7 @@ def test_sampler(tmpdir, batch_size, num_threads):
     }
 
     preprocessor = TrainingProcessor(config, "", str(tmpdir))
-    data_path, train_dir, num_samples, summary, metadata = \
+    data_path, train_dir, num_samples, summary = \
         preprocessor.generate_preprocessed_data()
     assert num_samples == 5000
     assert summary['news_pattern']['linesampled'] == 3000
@@ -109,7 +109,7 @@ def test_sampler(tmpdir, batch_size, num_threads):
 
     preprocessor = TrainingProcessor(config, "", str(tmpdir))
     with pytest.raises(RuntimeError) as excinfo:
-        data_path, train_dir, num_samples, summary, metadata = \
+        data_path, train_dir, num_samples, summary = \
             preprocessor.generate_preprocessed_data()
     assert str(excinfo.value) == "pattern '.*something' in block 0 doesn't match any file with strict mode enabled."
 
@@ -127,7 +127,7 @@ def test_sampler(tmpdir, batch_size, num_threads):
     ]
 
     preprocessor = TrainingProcessor(config, "", str(tmpdir))
-    data_path, train_dir, num_samples, summary, metadata = \
+    data_path, train_dir, num_samples, summary = \
         preprocessor.generate_preprocessed_data()
 
     assert num_samples == 6000
@@ -181,7 +181,7 @@ def test_sampler_with_annotations(tmpdir, similarity_filter_config, expected_num
     }
 
     preprocessor = TrainingProcessor(config, from_dir, to_dir)
-    data_path, train_dir, num_samples, summary, metadata = preprocessor.generate_preprocessed_data()
+    data_path, train_dir, num_samples, summary = preprocessor.generate_preprocessed_data()
 
     assert 'annotations' in summary['train'] and summary['train']['annotations'] == ['similarity']
     if expected_num_samples is not None:
@@ -377,7 +377,7 @@ def test_preprocess_pipeline(tmpdir):
 
 
     preprocessor = TrainingProcessor(config, "", str(tmpdir))
-    data_path, train_dir, num_samples, summary, metadata = \
+    data_path, train_dir, num_samples, summary = \
         preprocessor.generate_preprocessed_data()
 
     for f_name, f_info in summary.items():
@@ -550,7 +550,7 @@ def test_preprocess_align(tmpdir, num_cpus):
     os.environ["NB_CPU"] = str(num_cpus)
 
     preprocessor = TrainingProcessor(config_base, "", str(tmpdir))
-    data_path, train_dir, num_samples, summary, metadata = \
+    data_path, train_dir, num_samples, summary = \
         preprocessor.generate_preprocessed_data()
 
     with open(os.path.join(str(tmpdir), "preprocess", "europarl-v7.de-en.10K.tok.align")) as align:
@@ -697,7 +697,7 @@ def test_replace_tokens(tmpdir):
     )
 
     preprocessor = TrainingProcessor(config_replace, "", str(tmpdir))
-    data_path, train_dir, num_samples, summary, metadata = \
+    data_path, train_dir, num_samples, summary = \
         preprocessor.generate_preprocessed_data()
 
 
@@ -721,7 +721,7 @@ def test_extra_target(tmpdir):
     config_extra_target['preprocess'].insert(0, { "op": "extra_target" })
 
     preprocessor = TrainingProcessor(config_extra_target, "", str(tmpdir))
-    data_path, train_dir, num_samples, summary, metadata = \
+    data_path, train_dir, num_samples, summary = \
         preprocessor.generate_preprocessed_data()
 
     with open(str(tmpdir.join("preprocess/europarl-v7.de-en.10K.tok.en"))) as f :


### PR DESCRIPTION
This mode was used by OpenNMT-lua which accepted additional key-value options for each corpus. This is no longer useful and we can now assume the training frameworks do not need to know per-corpus information.