### PR TITLE
Restructure multiprocessing

### DIFF
--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -151,6 +151,9 @@ class Pipeline(object):
 
         self._build_pipeline(config, preprocess_exit_step, shared_state)
 
+    @property
+    def process_type(self):
+        return self._process_type
 
     def _add_op_list(self, op_list_config, exit_step=None, shared_state=None):
         # Parameters from global configuration that can be useful for individual operators.

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -803,8 +803,8 @@ def test_shared_state_with_overrides(num_workers):
         ],
     }
 
-    processor = Processor(config, prepoperator.ProcessType.TRAINING)
+    processor = Processor(config, prepoperator.ProcessType.TRAINING, num_workers=num_workers)
     loader = CustomLoader([None, "two", "one", None])
     consumer = CustomConsumer()
 
-    processor.process(loader, consumer, num_workers=num_workers)
+    processor.process(loader, consumer)


### PR DESCRIPTION
This commit addresses several issues:

* The parallelization was done on the method `self.process_batch`. This
  has the unwanted effect of serializing `self` and requiring a
  rebuild of the pipeline in the worker process.
  => The processing function has been moved outside the class and the
  pipeline is now properly cached on the worker process with a global
  variable.

* The shared state was regenerated in each call to `process()`, but this
  should be avoided as shared objects are usually expensive to create.
  => The number of workers is now resolved in the constructor and the
  shared state is created there.

* When building vocabularies, the pipeline should be manually reset
  between the subword generation and the vocabulary generation.
  => The `process()` method will always build a new pipeline.