### PR TITLE
Consume "tokens_to_add" in a separate consumer

### DIFF
--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -892,14 +892,10 @@ class Framework(utility.Utility):
         return converted_vocab_file
 
     def _build_data(self, config):
-        data_dir, train_dir, num_samples, distribution_summary = (
+        data_dir, train_dir, num_samples, distribution_summary, tokens_to_add = (
             self._generate_training_data(config))
         if num_samples == 0:
             raise RuntimeError('data sampling generated 0 sentences')
-        if distribution_summary is not None:
-            tokens_to_add = distribution_summary.get("tokens_to_add")
-        else:
-            tokens_to_add = None
         data_dir = self._merge_multi_training_files(
             data_dir, train_dir, config['source'], config['target'])
         return data_dir, num_samples, distribution_summary, tokens_to_add

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -216,10 +216,7 @@ class ReplaceVocabChecker(_TestFramework):
 
     def _generate_training_data(self, config):
         outputs = list(super(ReplaceVocabChecker, self)._generate_training_data(config))
-        if not outputs[-1]:
-            outputs[-1] = {}
-        outputs[-1]["tokens_to_add"] = dict(
-            source=self.src_tokens_to_add, target=self.tgt_tokens_to_add)
+        outputs[-1] = dict(source=self.src_tokens_to_add, target=self.tgt_tokens_to_add)
         return tuple(outputs)
 
 config_base = {


### PR DESCRIPTION
This change addresses 2 issues:

* The logic of reading the "tokens_to_add" field set by operators was
  duplicated in 2 different consumers.

* The "tokens_to_add" field was finally added to the distribution
  summary. However, it is unrelated to the distribution summary and
  should be a separate return value.