### PR TITLE
Only create SamplerFile object for sampled files

### DIFF
--- a/nmtwizard/preprocess/loader.py
+++ b/nmtwizard/preprocess/loader.py
@@ -121,10 +121,14 @@ class SamplerFileLoader(Loader):
                     num_samples -= 1
 
         try:
-            batch_meta = self._file.weight.copy()
-            batch_meta["base_name"] = self._file.base_name
-            batch_meta["root"] = self._file.root
-            batch_meta["no_preprocess"] = self._file.no_preprocess
+            batch_meta = {
+                "base_name": self._file.base_name,
+                "label": self._file.label,
+                "no_preprocess": self._file.no_preprocess,
+                "pattern": self._file.pattern,
+                "root": self._file.root,
+                "weight": self._file.weight,
+            }
 
             tu_list = []
 

--- a/nmtwizard/preprocess/sampler.py
+++ b/nmtwizard/preprocess/sampler.py
@@ -177,8 +177,7 @@ def sample(config, source_dir):
                         # Different paths in distribution produced files with the same name.
                         # This is not allowed since we write output files in the same folder.
                         raise RuntimeError('Two files with the same name %s where sampled.' % base_name)
-                    else:
-                        all_files[base_name] = sampler_file
+                    all_files[base_name] = sampler_file
 
         return all_files, pattern_weights_sum, pattern_sizes
 


### PR DESCRIPTION
Before this change, there were checks on the "weight" attribute to
determine whether the file was sampled. But all SamplerFile objects
should represent files that are actually matched by a pattern.

This change also sets all expected attributes in the SamplerFile
constructor.