### PR TITLE
Get length from serialized tokens

### DIFF
--- a/nmtwizard/preprocess/operators/align_perplexity_filter.py
+++ b/nmtwizard/preprocess/operators/align_perplexity_filter.py
@@ -53,8 +53,8 @@ class AlignPerplexityFilter(prepoperator.Filter):
 def _compute_perplexity(tu):
     # Compute the average source/target perplexity.
     fwd, bwd = _get_log_probs(tu)
-    src_size = len(tu.src_tok.token_objects[0])
-    tgt_size = len(tu.tgt_tok.token_objects[0])
+    src_size = len(tu.src_tok.tokens[0])
+    tgt_size = len(tu.tgt_tok.tokens[0])
     return (math.exp(-fwd / src_size) + math.exp(-bwd / tgt_size)) / 2
 
 def _get_log_probs(tu):

--- a/nmtwizard/preprocess/operators/length_filter.py
+++ b/nmtwizard/preprocess/operators/length_filter.py
@@ -11,22 +11,22 @@ class LengthFilter(prepoperator.Filter):
         filters.extend(_get_side_filters(
             source_config,
             lambda tu: tu.src_detok,
-            lambda tu: tu.src_tok.token_objects[0]))
+            lambda tu: tu.src_tok.tokens[0]))
         filters.extend(_get_side_filters(
             target_config,
             lambda tu: tu.tgt_detok,
-            lambda tu: tu.tgt_tok.token_objects[0]))
+            lambda tu: tu.tgt_tok.tokens[0]))
 
 
         min_words_ratio = config.get('min_words_ratio')
         if min_words_ratio is not None:
             filters.append(lambda tu: (
-                len(tu.src_tok.token_objects[0]) / len(tu.tgt_tok.token_objects[0]) < min_words_ratio))
+                len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0]) < min_words_ratio))
 
         max_words_ratio = config.get('max_words_ratio')
         if max_words_ratio is not None:
             filters.append(lambda tu: (
-                len(tu.src_tok.token_objects[0]) / len(tu.tgt_tok.token_objects[0]) > max_words_ratio))
+                len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0]) > max_words_ratio))
 
         super(LengthFilter, self).__init__(filters)
 


### PR DESCRIPTION
In most cases, the serialized and deserialized lengths are the same in these operators. So let's simply use the serialized version to avoid a deserialization.