### PR TITLE
Stupid replace_token function

### DIFF
--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -226,9 +226,8 @@ class TranslationSide(object):
     def replace_tokens(self, start_idx, tok_num, new_tokens=None, part=0):
 
         # check/initialize tokenization if not done already
-        cur_tokens = self.__tok
+        cur_tokens = self.__tok[part]
         if cur_tokens is not None:
-            cur_tokens = self.__tokenizer.deserialize_tokens(cur_tokens[part])
             cur_length = len(cur_tokens)
             if start_idx > cur_length:
                 raise IndexError('Start index is too big for replacement.')
@@ -241,18 +240,12 @@ class TranslationSide(object):
                 if start_idx < cur_length:
                     del cur_tokens[start_idx:end_idx]
             else:
-                if not isinstance(new_tokens[0], pyonmttok.Token):
-                    new_tokens = self.__tokenizer.deserialize_tokens(new_tokens)
-
                 if start_idx == end_idx:  # Insertion.
                     cur_tokens[start_idx:start_idx] = new_tokens
                 else:  # Replacement.
-                    new_tokens[0].join_left = cur_tokens[start_idx].join_left
-                    new_tokens[-1].join_right = cur_tokens[end_idx - 1].join_right
                     cur_tokens[start_idx:end_idx] = new_tokens
 
             self.__detok = None
-            self.__tok[part] = self.__tokenizer.serialize_tokens(cur_tokens)[0]
         else:
             logger.warning("Cannot replace tokens, no tokenization is set.")
 

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -226,8 +226,9 @@ class TranslationSide(object):
     def replace_tokens(self, start_idx, tok_num, new_tokens=None, part=0):
 
         # check/initialize tokenization if not done already
-        cur_tokens = self.__tok[part]
+        cur_tokens = self.__tok
         if cur_tokens is not None:
+            cur_tokens = cur_tokens[part]
             cur_length = len(cur_tokens)
             if start_idx > cur_length:
                 raise IndexError('Start index is too big for replacement.')

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -740,22 +740,10 @@ def test_replace_tokens(tmpdir):
 
         def _preprocess_tu(self, tu, training):
 
-            def joiner_side(tokens, pos, num_to_del):
-                joiner_start = False
-                joiner_end = False
-                if num_to_del:
-                    joiner_start = tokens[0][pos].startswith(joiner_marker)
-                    joiner_end = tokens[0][pos+num_to_del-1].endswith(joiner_marker)
-                return joiner_start, joiner_end
-
-            def checks_side(tokens, length, pos, num_to_del, tok_replace, joiner_start, joiner_end):
+            def checks_side(tokens, length, pos, num_to_del, tok_replace):
                 assert(len(tokens[0]) == length - num_to_del + len(tok_replace))
 
                 if tok_replace:
-                    if joiner_start:
-                        tok_replace[0] = joiner_marker + tok_replace[0]
-                    if joiner_end:
-                        tok_replace[-1] += joiner_marker
                     assert (tokens[0][pos:pos+len(tok_replace)] == tok_replace)
 
             def change_align_side(al_idx, pos, num_to_del, tok_replace):
@@ -788,11 +776,6 @@ def test_replace_tokens(tmpdir):
                 src_pos, src_num_to_del, src_tok_replace = src_replace
                 tgt_pos, tgt_num_to_del, tgt_tok_replace = tgt_replace
 
-                src_joiner_start, src_joiner_end = joiner_side(
-                    tu.src_tok.tokens, src_pos, src_num_to_del)
-                tgt_joiner_start, tgt_joiner_end = joiner_side(
-                    tu.tgt_tok.tokens, tgt_pos, tgt_num_to_del)
-
                 tu.replace_tokens(src_replace, tgt_replace)
 
                 checks_side(
@@ -800,17 +783,13 @@ def test_replace_tokens(tmpdir):
                     src_len,
                     src_pos,
                     src_num_to_del,
-                    src_tok_replace,
-                    src_joiner_start,
-                    src_joiner_end)
+                    src_tok_replace)
                 checks_side(
                     tu.tgt_tok.tokens,
                     tgt_len,
                     tgt_pos,
                     tgt_num_to_del,
-                    tgt_tok_replace,
-                    tgt_joiner_start,
-                    tgt_joiner_end)
+                    tgt_tok_replace)
 
                 # Check alignment
                 alignment_after = tu.alignment[0]


### PR DESCRIPTION
replace_token function is now based on string tokens and doesn't check joiner propagation