### PR TITLE
Remove no longer needed Tokenizer detach

### DIFF
--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -214,11 +214,6 @@ class TranslationSide(object):
         self.__detok = detok
         self.__tok = None
 
-    def finalize(self):
-        _ = self.tok
-        _ = self.detok
-        self.__tokenizer = None
-
     def append(self, other):
         other_token_objects = other.tok.token_objects
         if other_token_objects is None:
@@ -491,9 +486,6 @@ class TranslationUnit(object):
         sides_to_merge = (ts for k, ts in all_sides if k != "main" and ts.output_side == name)
         for ts in sides_to_merge:
             main_side.append(ts)
-
-        # Synchronize the main side and detach the Tokenizer instance.
-        main_side.finalize()
 
         # Remove secondary sides.
         for key in list(side.keys()):


### PR DESCRIPTION
Detaching the Tokenizer from the TU instance was initially needed for
multiprocessing because Tokenizer instances could not not be
transferred from the worker process to the master process.

However, since #242 TU instances are exported in a separate structure
so this operation is no longer needed.