### PR TITLE
Always forward configuration overrides to InferenceProcessor

### DIFF
--- a/nmtwizard/config.py
+++ b/nmtwizard/config.py
@@ -85,7 +85,7 @@ def build_override(config, path, value):
     inner_path = '/'.join(sections[1:])
     if isinstance(config, dict):
         return {section: build_override(config.get(section), inner_path, value)}
-    elif isinstance(config, list):
+    if isinstance(config, list):
         index = int(sections[0])
         override = build_override(config[index], inner_path, value)
         # Since lists can't be merged, the override should contain the full list content.
@@ -95,8 +95,7 @@ def build_override(config, path, value):
         else:
             config[index] = override
         return config
-    else:
-        raise TypeError('Paths in config can only represent object and array structures')
+    raise TypeError('Paths in config can only represent object and array structures')
 
 def index_schema(schema, path):
     """Index a JSON schema with a path-like string."""

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -1,10 +1,12 @@
 """Functions for corpus preprocessing."""
 
+import copy
 import collections
 import multiprocessing
 import multiprocessing.managers
 import os
 
+from nmtwizard import config as config_util
 from nmtwizard import utils
 from nmtwizard.logger import get_logger
 from nmtwizard.preprocess import consumer
@@ -388,7 +390,7 @@ class InferenceProcessor(Processor):
             list of tokens.
           target_name: The name of the target that is passed during inference.
           metadata: Additional metadata of the input.
-          config: The configuration for this example.
+          config: A configuration override for this example.
           options: A dictionary with operators options.
 
         Returns:
@@ -399,7 +401,11 @@ class InferenceProcessor(Processor):
         # thread for each request.
 
         # Rebuild pipeline if the example has its own configuration.
-        if config is not None:
+        if config:
+            if config_util.is_v2_config(self._config):
+                raise ValueError("Configuration override is not supported for V2 "
+                                 "configurations")
+            config = config_util.merge_config(copy.deepcopy(self._config), config)
             pipeline = prepoperator.Pipeline(
                 config,
                 self._pipeline_type,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -142,11 +142,27 @@ def test_read_options():
         config.read_options(cfg, options)
 
     options = {"bpreprocess": {"domain": "IT"}}
-    config.get_options(cfg, options)
-    assert cfg["bpreprocess"]["classifiers"][1]["value"] == "IT"
+    config.read_options(cfg, options) == {
+        "bpreprocess": {
+            "classifiers": [
+                {
+                    "name": "politeness"
+                },
+                {
+                    "name": "domain",
+                    "value": "IT",
+                }
+            ]
+        }
+    }
 
-def test_read_options():
+def test_read_options_v2():
     cfg = copy.deepcopy(_test_config_v2)
     cfg['inference_options'] = copy.deepcopy(_test_inference_options_v2)
     options = {"bpreprocess": {"domain": "IT"}}
     assert config.read_options(cfg, options) == {"my-domain-op": {"value": "IT"}}
+
+def test_build_override():
+    c = {"a": {"b": {"c": 42}, "d": [{"e": 43}, {"f": 44}]}}
+    assert config.build_override(c, "a/z", 45) == {"a": {"z": 45}}
+    assert config.build_override(c, "a/d/1/g", 45) == {"a": {"d": [{"e": 43}, {"f": 44, "g": 45}]}}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -142,7 +142,7 @@ def test_read_options():
         config.read_options(cfg, options)
 
     options = {"bpreprocess": {"domain": "IT"}}
-    config.read_options(cfg, options) == {
+    assert config.read_options(cfg, options) == {
         "bpreprocess": {
             "classifiers": [
                 {

--- a/test/test_serving.py
+++ b/test/test_serving.py
@@ -203,7 +203,7 @@ def test_preprocess_examples():
     assert examples[0].config == {"a": 42}
     assert examples[0].source_tokens == [["a", "b", "c"]]
     assert examples[0].metadata == [3]
-    assert examples[1].config == {"a": 24}
+    assert examples[1].config is None
     assert examples[1].source_tokens == [["d", "e", "f"], ["g"]]
     assert examples[1].metadata == [3, 1]
 
@@ -420,17 +420,6 @@ def test_run_request_with_v2_config():
             },
         ],
     }
-
-    with pytest.raises(serving.InvalidRequest, match="override is not supported"):
-        request = {"src": [{"text": "a b c", "config": {"override": 42}}]}
-        serving.run_request(
-            request,
-            translate,
-            Preprocessor(),
-            Postprocessor(),
-            config=config,
-            rebatch_request=False,
-            max_batch_size=1)
 
     request = {"src": [{"text": "a b c"}]}
     result = serving.run_request(


### PR DESCRIPTION
Before this change, configuration overrides were not allowed when using a V2 configuration. However, to keep compatibility with existing inference requests we might want to accept such requests.

In this change, the serving code no longer applies the configuration override but instead passes it to the InferenceProcessor. The processor can then decide to:

* apply the override (e.g. a V1 configuration)
* map known overrides to operators options (e.g. V2 configuration with legacy overrides)
* reject the override (e.g. V2 configuration with unsupported overrides)