### PR TITLE
Fix align_perplexity_filter

### DIFF
--- a/nmtwizard/preprocess/operators/align_perplexity_filter.py
+++ b/nmtwizard/preprocess/operators/align_perplexity_filter.py
@@ -60,9 +60,9 @@ class AlignPerplexityFilter(prepoperator.Filter):
 
 def _get_hard_threshold(config, field):
     value = config.get(field)
-    if value is not None and value < 1:
+    if value is not None and value > 0:
         raise ValueError("align_perplexity_filter: perplexity values range from "
-                         "+1 (best perplexity) to +inf (worst perplexity), but hard "
+                         "-inf (worst perplexity) to 0 (best perplexity), but hard "
                          "threshold '%s' is set to %.2f" % (field, value))
     return value
 

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -209,8 +209,8 @@ def test_align_perplexity_invalid_config(mode, lower, upper):
 
 @pytest.mark.parametrize("lower,upper,src_length,tgt_length,fwd_log_prob,bwd_log_prob,filtered", [
     (None, None, 5, 7, -5.1, -8.2, False),
-    (2, None, 5, 5, 0, 0, True),  # ppl = 1
-    (1, 10, 5, 5, 0, 0, False),  # ppl = 1
+    (-1, 0, 5, 5, 0, 0, False),
+    (-10, -2, 5, 5, -5.1, -8.2, True),
 ])
 def test_align_perplexity_hard_threshold(lower,
                                          upper,


### PR DESCRIPTION
It is not a good idea to inverse log probabilities (-fwd, -bwd) from negative to positive before exponentiation, because exp of a positive value quickly becomes huge and even overflows sometimes.

I think it is best to keep negative values, take an exp of those ( between 0 and 1 ), and then take a log of the result to avoid very small values close to 0 (and to be closer to the original log values).

Also, in my experiments, it seems better to normalize by minimum word length (between src and tgt).
The resulting value seems closer to what we are looking for : find badly aligned sentences without penalizing long sentences.