### PR TITLE
Merge V2 configurations by default

### DIFF
--- a/nmtwizard/config.py
+++ b/nmtwizard/config.py
@@ -41,9 +41,7 @@ def update_config(a, b, mode="default"):
         a = {k: v for k, v in a.items() if k in _non_user_fields}
         return replace_config(a, b)
 
-    if mode == "default":
-        mode = "merge" if from_version == 1 else "replace"
-    if mode == "merge":
+    if mode == "default" or mode == "merge":
         return merge_config(a, b)
     if mode == "replace":
         return replace_config(a, b)

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -494,12 +494,9 @@ def test_train_chain(tmpdir):
     assert DummyCheckpoint(model_dir).index() == 1
 
 
-# For V2 configuration, the default config update mode is "replace" while it is "merge"
-# for V1 configuration.
 @pytest.mark.parametrize(
     "config,custom_field,new_field,mode,expected_field",
     [
-        (config_base, {"a": 1, "b": 2}, {"a": 3}, "default", {"a": 3}),
         (config_base_old, {"a": 1, "b": 2}, {"a": 3}, "default", {"a": 3, "b": 2}),
         (config_base_old, {"a": 1, "b": 2}, {"a": 3}, "replace", {"a": 3}),
     ],


### PR DESCRIPTION
The "preprocess" and "postprocess" fields are lists so they will still be replaced, not merged. For other parts of the configuration (e.g. training options), it might be clearer to merge by default.