### PR TITLE
Add fields from local config

### DIFF
--- a/nmtwizard/config.py
+++ b/nmtwizard/config.py
@@ -216,6 +216,19 @@ def get_config_version(config):
     return 2 if is_v2_config(config) else 1
 
 
+def ensure_operators_name(config):
+    """Make sure all operators in model configuration have a unique name."""
+    i = 1
+    for process in ["preprocess", "postprocess"]:
+        process_config = config.get(process)
+        if process_config:
+            for op_config in process_config:
+                op_type = op_config.get("op")
+                if op_type:
+                    op_config.setdefault("name", "%s_%d" % (op_type, i))
+        i += 1
+
+
 def old_to_new_config(config):
     """Locally update old configuration with 'tokenization' field to include new 'vocabulary' and 'preprocess" fields."""
     if not config:

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1157,11 +1157,12 @@ class Framework(utility.Utility):
                 dist["path"] = os.path.join(basedir, dist["path"])
         return config
 
+
 def add_config_fields(config, local_config):
     if isinstance(config, dict) and isinstance(local_config, dict):
         name = local_config.get("name")
         op = local_config.get("op")
-        if name and op and (op == config.get("op")) :
+        if name and op and (op == config.get("op")):
             config.setdefault("name", name)
 
 

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1134,6 +1134,7 @@ class Framework(utility.Utility):
         return build_info
 
     def _finalize_config(self, config, training=True):
+        config_util.ensure_operators_name(config)
         config = config_util.old_to_new_config(config)
         config = utility.resolve_environment_variables(config, training=training)
         config = self._upgrade_data_config(config, training=training)
@@ -1158,14 +1159,6 @@ class Framework(utility.Utility):
         return config
 
 
-def add_config_fields(config, local_config):
-    if isinstance(config, dict) and isinstance(local_config, dict):
-        name = local_config.get("name")
-        op = local_config.get("op")
-        if name and op and (op == config.get("op")):
-            config.setdefault("name", name)
-
-
 def bundle_dependencies(objects, config, local_config):
     """Bundles additional resources in the model package."""
     if local_config is None:
@@ -1179,7 +1172,6 @@ def bundle_dependencies(objects, config, local_config):
             if k in ("sample_dist", "build"):
                 continue
             config[k] = bundle_dependencies(objects, v, local_config.get(k))
-        add_config_fields(config, local_config)
         return config
     else:
         if isinstance(config, six.string_types):

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1157,6 +1157,13 @@ class Framework(utility.Utility):
                 dist["path"] = os.path.join(basedir, dist["path"])
         return config
 
+def add_config_fields(config, local_config):
+    if isinstance(config, dict) and isinstance(local_config, dict):
+        name = local_config.get("name")
+        op = local_config.get("op")
+        if name and op and (op == config.get("op")) :
+            config.setdefault("name", name)
+
 
 def bundle_dependencies(objects, config, local_config):
     """Bundles additional resources in the model package."""
@@ -1171,6 +1178,7 @@ def bundle_dependencies(objects, config, local_config):
             if k in ("sample_dist", "build"):
                 continue
             config[k] = bundle_dependencies(objects, v, local_config.get(k))
+        add_config_fields(config, local_config)
         return config
     else:
         if isinstance(config, six.string_types):

--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -57,7 +57,7 @@ def operator_info_generator(
         ):
             ignore_disabled = False
         operator_params = get_operator_params(
-            operator_config, operator_type, override_label=override_label
+            operator_config, operator_type, i, override_label=override_label
         )
         if ignore_disabled and operator_params.get("disabled", False):
             continue
@@ -81,8 +81,9 @@ def get_operator_class(op):
     return operator_cls
 
 
-def get_operator_params(config, operator_type, override_label=None):
+def get_operator_params(config, operator_type, index,override_label=None):
     """Returns the operator parameters from the configuration."""
+    config.setdefault("name", "%s_%d" % (operator_type, index))
     config = copy.deepcopy(config)
     config.pop("op", None)
     override_config = config.pop("overrides", None)
@@ -130,7 +131,7 @@ def build_operator(
     args = []
     if shared_state:
         args.append(shared_state)
-    name = operator_params.pop("name", "%s_%d" % (operator_type, index))
+    name = operator_params["name"]
     if inference_config:
         op_inference_config = inference_config.get(name)
         if op_inference_config:
@@ -325,6 +326,7 @@ class Operator(object):
                 "comment": {"type": "string"},
                 "overrides": {"type": "object"},
                 "disabled": {"type": "boolean"},
+                "name": {"type": "string"}
             },
             "additionalProperties": False,
         }

--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -57,7 +57,7 @@ def operator_info_generator(
         ):
             ignore_disabled = False
         operator_params = get_operator_params(
-            operator_config, operator_type, i, override_label=override_label
+            operator_config, operator_type, override_label=override_label
         )
         if ignore_disabled and operator_params.get("disabled", False):
             continue
@@ -81,9 +81,8 @@ def get_operator_class(op):
     return operator_cls
 
 
-def get_operator_params(config, operator_type, index, override_label=None):
+def get_operator_params(config, operator_type, override_label=None):
     """Returns the operator parameters from the configuration."""
-    config.setdefault("name", "%s_%d" % (operator_type, index))
     config = copy.deepcopy(config)
     config.pop("op", None)
     override_config = config.pop("overrides", None)
@@ -131,7 +130,7 @@ def build_operator(
     args = []
     if shared_state:
         args.append(shared_state)
-    name = operator_params["name"]
+    name = operator_params.get("name", "%s_%d" % (operator_type, index + 1))
     if inference_config:
         op_inference_config = inference_config.get(name)
         if op_inference_config:

--- a/nmtwizard/preprocess/prepoperator.py
+++ b/nmtwizard/preprocess/prepoperator.py
@@ -81,7 +81,7 @@ def get_operator_class(op):
     return operator_cls
 
 
-def get_operator_params(config, operator_type, index,override_label=None):
+def get_operator_params(config, operator_type, index, override_label=None):
     """Returns the operator parameters from the configuration."""
     config.setdefault("name", "%s_%d" % (operator_type, index))
     config = copy.deepcopy(config)
@@ -326,7 +326,7 @@ class Operator(object):
                 "comment": {"type": "string"},
                 "overrides": {"type": "object"},
                 "disabled": {"type": "boolean"},
-                "name": {"type": "string"}
+                "name": {"type": "string"},
             },
             "additionalProperties": False,
         }

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -477,7 +477,7 @@ def test_train_with_sampling_v2(tmpdir):
         tmpdir, "model0", "train", config=config, corpus_env=False
     )
     config = _read_config(model_dir)
-    assert config["preprocess"][0]["name"] == "tokenization_0"
+    assert config["preprocess"][0]["name"] == "tokenization_1"
     assert config["build"]["sentenceCount"] == 1000
     assert os.path.exists(os.path.join(model_dir, "en-vocab.txt"))
     assert not os.path.exists(os.path.join(model_dir, "de-vocab.txt"))

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -477,6 +477,7 @@ def test_train_with_sampling_v2(tmpdir):
         tmpdir, "model0", "train", config=config, corpus_env=False
     )
     config = _read_config(model_dir)
+    assert (config['preprocess'][0]["name"] == 'tokenization_0')
     assert config["build"]["sentenceCount"] == 1000
     assert os.path.exists(os.path.join(model_dir, "en-vocab.txt"))
     assert not os.path.exists(os.path.join(model_dir, "de-vocab.txt"))

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -477,7 +477,7 @@ def test_train_with_sampling_v2(tmpdir):
         tmpdir, "model0", "train", config=config, corpus_env=False
     )
     config = _read_config(model_dir)
-    assert (config['preprocess'][0]["name"] == 'tokenization_0')
+    assert config["preprocess"][0]["name"] == "tokenization_0"
     assert config["build"]["sentenceCount"] == 1000
     assert os.path.exists(os.path.join(model_dir, "en-vocab.txt"))
     assert not os.path.exists(os.path.join(model_dir, "de-vocab.txt"))

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -159,7 +159,7 @@ def test_tokenization_with_inference_config(tmpdir):
     assert tu_list[0].tgt_tok.tokens[0] == ["2", ",", "000"]
 
     config["inference"] = {
-        "overrides": {"tokenization_0": {"source": {"mode": "none"}}}
+        "overrides": {"tokenization_1": {"source": {"mode": "none"}}}
     }
     pipeline = prepoperator.Pipeline(config, process_type)
 


### PR DESCRIPTION
As discussed, I would like to add a name to the preprocess operators in the model configuration, even if the user doesn't specify any explicitly.

Since we use a local configuration for preprocess, we need to retrieve those names from the local configuration.

Not sure this is the best way to do it, your ideas are welcome.