### PR TITLE
Compute alignment on a batch

### DIFF
--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -93,17 +93,9 @@ class Alignment(object):
     def log_probs(self):
         return self.__log_probs
 
-    def set_alignments(self, aligner, src_tok, tgt_tok):
-        alignments = []
-        log_probs = []
-        for src_tok_part, tgt_tok_part in zip(src_tok, tgt_tok):
-            align_result = aligner.align(src_tok_part, tgt_tok_part)
-            alignments.append(set(align_result["alignments"]))
-            log_probs.append(
-                (align_result["forward_log_prob"], align_result["backward_log_prob"])
-            )
-        self.__alignments = alignments
-        self.__log_probs = log_probs
+    def set_alignments(self, alignments, forward_log_prob, backward_log_prob):
+        self.__alignments = [alignments]
+        self.__log_probs = [(forward_log_prob, backward_log_prob)]
 
     def adjust_alignment(self, side_idx, start_idx, tok_num, new_tokens=None, part=0):
         # Shift alignments behind insertion/deletion.
@@ -454,13 +446,9 @@ class TranslationUnit(object):
             return None
         return list(log_probs)
 
-    def set_alignment(self, aligner):
-        if self.src_tok.tokenizer is None or self.tgt_tok.tokenizer is None:
-            raise RuntimeError("Cannot set alignment if not tokenization is set.")
+    def set_alignment(self, alignments, forward_log_prob=0, backward_log_prob=0):
         self.__alignment = Alignment()
-        self.__alignment.set_alignments(
-            aligner, self.src_tok.tokens, self.tgt_tok.tokens
-        )
+        self.__alignment.set_alignments(alignments, forward_log_prob, backward_log_prob)
 
     @property
     def src_detok(self):

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -94,7 +94,7 @@ class Alignment(object):
         return self.__log_probs
 
     def set_alignments(self, alignments, forward_log_prob, backward_log_prob):
-        self.__alignments = [alignments]
+        self.__alignments = [set(alignments)]
         self.__log_probs = [(forward_log_prob, backward_log_prob)]
 
     def adjust_alignment(self, side_idx, start_idx, tok_num, new_tokens=None, part=0):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jsonschema==3.*
 pyonmttok==1.26.4
 requests==2.*
 six>=1.13,<2
-systran-align>=3.2,<4
+systran-align>=3.3,<4

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -334,7 +334,9 @@ def test_align_perplexity_hard_threshold(
         source_tokenizer=tokenizer,
         target_tokenizer=tokenizer,
     )
-    single_tu.set_alignment([], forward_log_prob=fwd_log_prob, backward_log_prob=bwd_log_prob)
+    single_tu.set_alignment(
+        [], forward_log_prob=fwd_log_prob, backward_log_prob=bwd_log_prob
+    )
     assert filtered == _is_filtered(config, single_tu)
 
 
@@ -362,7 +364,9 @@ def test_align_perplexity_percent_threshold(
         single_tu = tu.TranslationUnit(
             "a b c", "a b c", source_tokenizer=tokenizer, target_tokenizer=tokenizer
         )
-        single_tu.set_alignment([], forward_log_prob=log_prob, backward_log_prob=log_prob)
+        single_tu.set_alignment(
+            [], forward_log_prob=log_prob, backward_log_prob=log_prob
+        )
         tu_list.append(single_tu)
 
     config = {

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -32,18 +32,6 @@ def _is_filtered(config, tu_list):
     return len(tu_list) == 0
 
 
-class _MockAligner:
-    def __init__(self, alignments=None, forward_log_prob=0, backward_log_prob=0):
-        self._result = {
-            "forward_log_prob": forward_log_prob,
-            "backward_log_prob": backward_log_prob,
-            "alignments": alignments or [],
-        }
-
-    def align(self, *args):
-        return self._result
-
-
 def test_tokenization_with_vocabulary_restriction(tmpdir):
     sp_model_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -346,9 +334,7 @@ def test_align_perplexity_hard_threshold(
         source_tokenizer=tokenizer,
         target_tokenizer=tokenizer,
     )
-    single_tu.set_alignment(
-        _MockAligner(forward_log_prob=fwd_log_prob, backward_log_prob=bwd_log_prob)
-    )
+    single_tu.set_alignment([], forward_log_prob=fwd_log_prob, backward_log_prob=bwd_log_prob)
     assert filtered == _is_filtered(config, single_tu)
 
 
@@ -376,9 +362,7 @@ def test_align_perplexity_percent_threshold(
         single_tu = tu.TranslationUnit(
             "a b c", "a b c", source_tokenizer=tokenizer, target_tokenizer=tokenizer
         )
-        single_tu.set_alignment(
-            _MockAligner(forward_log_prob=log_prob, backward_log_prob=log_prob)
-        )
+        single_tu.set_alignment([], forward_log_prob=log_prob, backward_log_prob=log_prob)
         tu_list.append(single_tu)
 
     config = {


### PR DESCRIPTION
Since alignment models requires a lot of memory, the `Aligner` instance is running in a separate process that each preprocessing worker interacts with. So each call to `Aligner.align` is an inter-process communication. In that case it is better to interact with this object in batch mode to improve performance.