### PR TITLE
Allow consuming processed batches in arbitrary order

### DIFF
--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -177,12 +177,12 @@ class Processor(object):
 
             def _get_iterator(semaphore):
                 for tu_batch in loader():
-                    # If the semaphore value reaches 0, the iterator will block so that no more
-                    # batches are loaded.
-                    semaphore.acquire()
                     override_label = _get_corpus_label(tu_batch)
                     shared_state = self._global_shared_state.get(override_label)
                     yield tu_batch, shared_state
+                    # If the semaphore value reaches 0, the iterator will block so that no more
+                    # batches are loaded.
+                    semaphore.acquire()
 
             process_func = functools.partial(
                 _process_batch_on_worker,


### PR DESCRIPTION
In the current implementation of multi-worker processing, the batches are consumed in the same order as they are loaded. However, this can cause performance issues when the processing time of each batch is very different, e.g. small batches with basic preprocessing and big batches with fuzzy match. When waiting on the result of a big batch, the other workers could finish their work and wait. In that case resources are wasted.

In practice it seems we don't need to consume the batches in the same order. They can be consumed as soon as they are processed by a worker.