### PR TITLE
Add score task

### DIFF
--- a/frameworks/opennmt_tf/entrypoint.py
+++ b/frameworks/opennmt_tf/entrypoint.py
@@ -69,9 +69,16 @@ class OpenNMTTFFramework(Framework):
         )
         return _list_checkpoint_files(output_dir), summary
 
+    def score(self, config, model_path, source, target, output, gpuid=0):
+        runner = self._build_runner(config, model_path=model_path)
+        runner.score(source, target, output_file=output)
+        return utils.ScoreType.CUMULATED_NLL
+
     def trans(self, config, model_path, input, output, gpuid=0):
         runner = self._build_runner(config, model_path=model_path)
         runner.infer(input, predictions_file=output)
+        with_scores = config["options"].get("config", {}).get("infer", {}).get("with_scores")
+        return utils.ScoreType.CUMULATED_LL if with_scores else None
 
     def release(self, config, model_path, optimization_level=None, gpuid=0):
         export_dir = os.path.join(self._output_dir, _SAVED_MODEL_DIR)

--- a/frameworks/opennmt_tf/entrypoint.py
+++ b/frameworks/opennmt_tf/entrypoint.py
@@ -77,7 +77,9 @@ class OpenNMTTFFramework(Framework):
     def trans(self, config, model_path, input, output, gpuid=0):
         runner = self._build_runner(config, model_path=model_path)
         runner.infer(input, predictions_file=output)
-        with_scores = config["options"].get("config", {}).get("infer", {}).get("with_scores")
+        with_scores = (
+            config["options"].get("config", {}).get("infer", {}).get("with_scores")
+        )
         return utils.ScoreType.CUMULATED_LL if with_scores else None
 
     def release(self, config, model_path, optimization_level=None, gpuid=0):

--- a/nmtwizard/preprocess/consumer.py
+++ b/nmtwizard/preprocess/consumer.py
@@ -548,7 +548,10 @@ class PostprocessFileWriter(FileWriter):
         return self._output_path
 
     def _write_output(self, output, files):
-        files[0].write(output)
+        output_line = output.tgt
+        if output.metadata and "score" in output.metadata:
+            output_line = "%.6f ||| %s" % (output.metadata["score"], output_line)
+        files[0].write(output_line)
         files[0].write("\n")
 
 

--- a/nmtwizard/preprocess/tu.py
+++ b/nmtwizard/preprocess/tu.py
@@ -532,7 +532,13 @@ class TranslationUnit(object):
 
     def export(self, process_type):
         if process_type == prepoperator.ProcessType.POSTPROCESS:
-            return self.tgt_detok
+            return PreprocessOutput(
+                src=self.src_detok,
+                tgt=self.tgt_detok,
+                metadata=self.metadata[0],
+                alignment=None,
+            )
+
         src = self.src_tok.tokens
         if src is None:
             src = self.src_detok

--- a/nmtwizard/utils.py
+++ b/nmtwizard/utils.py
@@ -5,10 +5,18 @@ import subprocess
 import six
 import os
 import gzip
+import enum
 
 from nmtwizard.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class ScoreType(enum.Enum):
+    CUMULATED_LL = 0
+    CUMULATED_NLL = 1
+    NORMALIZED_LL = 2
+    NORMALIZED_NLL = 3
 
 
 def md5file(path):

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -803,6 +803,32 @@ def test_postprocess_multipart_file_loader(tmpdir):
     assert utils.count_lines(output_path)[1] == 4
 
 
+def test_postprocess_multipart_file_loader_with_scores(tmpdir):
+    src_path = str(tmpdir.join("src.txt"))
+    tgt_path = str(tmpdir.join("tgt.txt"))
+
+    with open(src_path, "w") as src_file:
+        src_file.write("1 2 3\n")
+        src_file.write("4 5\n")
+        src_file.write("6\n")
+    with open(tgt_path, "w") as tgt_file:
+        tgt_file.write("-0.1 ||| a b c\n")
+        tgt_file.write("-0.6 ||| d e\n")
+        tgt_file.write("-0.2 ||| f\n")
+
+    meta = [[None, None, None]]
+    processor = InferenceProcessor(config_base, postprocess=True)
+    output_path = processor.process_file(
+        src_path,
+        tgt_path,
+        meta,
+        target_score_type=utils.ScoreType.CUMULATED_LL,
+    )
+
+    with open(output_path) as output_file:
+        assert output_file.read().strip() == "-0.150000 ||| a b c d e f"
+
+
 def test_postprocess_multipart_batch_loader(tmpdir):
     processor = InferenceProcessor(config_base, postprocess=True)
 


### PR DESCRIPTION
This PR adds a `score` command to score existing translations and corpus. Each framework should return a `ScoreType` value to declare the type of score they are outputting. This type is used to make sure that we always output a normalized log probability.

This PR also fixes the postprocessing of translation outputs that contain scores.