### PR TITLE
Standalone model

### DIFF
--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -602,6 +602,7 @@ class Framework(utility.Utility):
 
         if parent_model_type == "standalone":
             objects["data"] = data_dir
+            objects["standalone_data"] = os.path.join(model_path, "standalone_data")
 
         # Build and push the model package.
         bundle_dependencies(objects, config, local_config)
@@ -1018,6 +1019,16 @@ class Framework(utility.Utility):
         # Build and push the model package.
         if parent_model_type == "checkpoint" and model_type == "standalone":
             objects = {"standalone_data": data_dir}
+            config["data"] = {
+                "sample": config.get("build", {}).get("sentenceCount") or config.get("sampling", {}).get("numSamples"),
+                "sample_dist": [
+                    {
+                        "distribution": [["train", 1]],
+                        "path": os.path.join("${MODEL_DIR}", "standalone_data"),
+                        "no_preprocess": True,
+                    }
+                ]
+            }
         else:
             objects = {"data": data_dir}
         keep_all_objects = (config["modelType"] == "standalone")

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1020,18 +1020,19 @@ class Framework(utility.Utility):
         if parent_model_type == "checkpoint" and model_type == "standalone":
             objects = {"standalone_data": data_dir}
             config["data"] = {
-                "sample": config.get("build", {}).get("sentenceCount") or config.get("sampling", {}).get("numSamples"),
+                "sample": config.get("build", {}).get("sentenceCount")
+                or config.get("sampling", {}).get("numSamples"),
                 "sample_dist": [
                     {
                         "distribution": [["train", 1]],
                         "path": os.path.join("${MODEL_DIR}", "standalone_data"),
                         "no_preprocess": True,
                     }
-                ]
+                ],
             }
         else:
             objects = {"data": data_dir}
-        keep_all_objects = (config["modelType"] == "standalone")
+        keep_all_objects = config["modelType"] == "standalone"
         bundle_dependencies(objects, config, local_config, keep_all_objects)
         # Forward other files from the parent model that are not tracked by the config.
         if model_path is not None:

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -345,7 +345,10 @@ class Framework(utility.Utility):
             )
             self._model_path = os.path.join(self._models_dir, parent_model)
             self._model_config = utility.fetch_model(
-                self._storage, remote_model_path, self._model_path, should_check_integrity
+                self._storage,
+                remote_model_path,
+                self._model_path,
+                should_check_integrity,
             )
             if "modelType" not in self._model_config:
                 if parent_model.endswith("_release"):
@@ -364,7 +367,7 @@ class Framework(utility.Utility):
                 "checkpoint",
                 "base",
                 "preprocess",
-                "stem"
+                "stem",
             ):
                 raise ValueError(
                     "cannot train from a model that is not a training checkpoint, "
@@ -393,7 +396,8 @@ class Framework(utility.Utility):
             )
         elif args.cmd == "trans":
             if not self._stateless and (
-                parent_model is None or config["modelType"] not in ("checkpoint", "stem")
+                parent_model is None
+                or config["modelType"] not in ("checkpoint", "stem")
             ):
                 raise ValueError("translation requires a training checkpoint")
             return self.trans_wrapper(
@@ -411,7 +415,8 @@ class Framework(utility.Utility):
             )
         elif args.cmd == "score":
             if not self._stateless and (
-                parent_model is None or config["modelType"] not in ("checkpoint", "stem")
+                parent_model is None
+                or config["modelType"] not in ("checkpoint", "stem")
             ):
                 raise ValueError("scoring requires a training checkpoint")
             return self.score_wrapper(
@@ -425,7 +430,8 @@ class Framework(utility.Utility):
             )
         elif args.cmd == "release":
             if not self._stateless and (
-                parent_model is None or config["modelType"] not in ("checkpoint", "stem")
+                parent_model is None
+                or config["modelType"] not in ("checkpoint", "stem")
             ):
                 raise ValueError("releasing requires a training checkpoint")
             if args.destination is None:
@@ -476,7 +482,7 @@ class Framework(utility.Utility):
                 if parent_model is not None and parent_model_type not in (
                     "checkpoint",
                     "base",
-                    "stem"
+                    "stem",
                 ):
                     raise ValueError(
                         "cannot preprocess from a model that is not a training "
@@ -521,9 +527,12 @@ class Framework(utility.Utility):
             del config["sampling"]
             logger.info("Using preprocessed data from %s" % data_dir)
         else:
-            data_dir, num_samples, distribution_summary, tokens_to_add = self._build_data(
-                local_config
-            )
+            (
+                data_dir,
+                num_samples,
+                distribution_summary,
+                tokens_to_add,
+            ) = self._build_data(local_config)
 
         src_vocab_info, tgt_vocab_info, _ = self._get_vocabs_info(
             config, local_config, model_config=model_config, tokens_to_add=tokens_to_add
@@ -1257,14 +1266,9 @@ class Framework(utility.Utility):
             config["data"].setdefault("sample", config["sampling"]["numSamples"])
             config["data"]["sample_dist"].append(
                 {
-                    "distribution": [
-                        [
-                            "train",
-                            1
-                        ]
-                    ],
+                    "distribution": [["train", 1]],
                     "path": os.path.join(self._model_path, "data"),
-                    "no_preprocess": True
+                    "no_preprocess": True,
                 }
             )
         preprocessor = self._get_preprocessor(config)

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -574,6 +574,7 @@ class Framework(utility.Utility):
         config["model"] = model_id
         if parent_model_type == "stem":
             config["modelType"] = "stem"
+            config["used_data"] = config["data"]
             del config["data"]
             config["sampling"] = {
                 "numSamples": num_samples,
@@ -995,6 +996,7 @@ class Framework(utility.Utility):
         config["model"] = model_id
         if model_type == "stem":
             config["modelType"] = "stem"
+            config["used_data"] = config["data"]
             del config["data"]
         else:
             config["modelType"] = "preprocess"

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1001,7 +1001,7 @@ class Framework(utility.Utility):
             config["modelType"] = "standalone"
             data = config.pop("data", None)
             if data:
-                if parent_model_type=="checkpoint":
+                if parent_model_type == "checkpoint":
                     config["standalone_data"] = data
                 else:
                     config["used_data"] = data
@@ -1024,7 +1024,7 @@ class Framework(utility.Utility):
         config["build"] = build_info
 
         # Build and push the model package.
-        if parent_model_type=="checkpoint":
+        if parent_model_type == "checkpoint":
             objects = {"standalone_data": data_dir}
         else:
             objects = {"data": data_dir}

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1028,7 +1028,7 @@ class Framework(utility.Utility):
             objects = {"standalone_data": data_dir}
         else:
             objects = {"data": data_dir}
-        keep_all_objects = True if config["modelType"] == "standalone" else False
+        keep_all_objects = (config["modelType"] == "standalone")
         bundle_dependencies(objects, config, local_config, keep_all_objects)
         # Forward other files from the parent model that are not tracked by the config.
         if model_path is not None:

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1024,7 +1024,7 @@ class Framework(utility.Utility):
         config["build"] = build_info
 
         # Build and push the model package.
-        if parent_model_type == "checkpoint":
+        if parent_model_type == "checkpoint" and model_type == "standalone":
             objects = {"standalone_data": data_dir}
         else:
             objects = {"data": data_dir}

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1273,7 +1273,7 @@ class Framework(utility.Utility):
         if model_type == "stem":
             config.setdefault("data", {})
             config["data"].setdefault("sample_dist", [])
-            config["data"].setdefault("sample", config["build"]["sentenceCount"])
+            config["data"].setdefault("sample", config.get("build", {}).get("sentenceCount") or config.get("sampling", {}).get("numSamples"))
             config["data"]["sample_dist"].append(
                 {
                     "distribution": [["train", 1]],

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1273,7 +1273,11 @@ class Framework(utility.Utility):
         if model_type == "stem":
             config.setdefault("data", {})
             config["data"].setdefault("sample_dist", [])
-            config["data"].setdefault("sample", config.get("build", {}).get("sentenceCount") or config.get("sampling", {}).get("numSamples"))
+            config["data"].setdefault(
+                "sample",
+                config.get("build", {}).get("sentenceCount")
+                or config.get("sampling", {}).get("numSamples"),
+            )
             config["data"]["sample_dist"].append(
                 {
                     "distribution": [["train", 1]],

--- a/nmtwizard/preprocess/preprocess.py
+++ b/nmtwizard/preprocess/preprocess.py
@@ -80,14 +80,16 @@ def _process_batch(
         )
 
     tu_list, batch_meta = tu_batch
-    base_name = _get_corpus_name(tu_batch)
-    logger.info(
-        "Processing %d samples%s",
-        len(tu_list),
-        " from %s" % base_name if base_name is not None else "",
-    )
 
-    tu_list, batch_meta = pipeline(tu_batch, options=options)
+    if not batch_meta.get("no_preprocess"):
+        base_name = _get_corpus_name(tu_batch)
+        logger.info(
+            "Processing %d samples%s",
+            len(tu_list),
+            " from %s" % base_name if base_name is not None else "",
+        )
+
+        tu_list, batch_meta = pipeline(tu_batch, options=options)
     outputs = [tu.export(pipeline.process_type) for tu in tu_list]
     return (outputs, batch_meta), pipeline
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -805,6 +805,71 @@ def test_preprocess_train_chain(tmpdir):
     assert DummyCheckpoint(model_dir).index() == 1
 
 
+def test_preprocess_as_standalone_model(tmpdir):
+    model_dir = _run_framework(
+        tmpdir, "checkpoint0", "train", config=config_base
+    )
+    config = _read_config(model_dir)
+    assert config["model"] == "checkpoint0"
+    assert config["modelType"] == "checkpoint"
+    assert not os.path.isdir(os.path.join(model_dir, "data"))
+
+    model_dir = _run_framework(
+        tmpdir, "standalone0", "preprocess --build_model standalone", parent="checkpoint0"
+    )
+    config = _read_config(model_dir)
+    assert config["model"] == "standalone0"
+    assert config["modelType"] == "standalone"
+    assert config["data"] == {'sample': 251, 'sample_dist': [{'distribution': [['train', 1]], 'path': '${MODEL_DIR}/standalone_data', 'no_preprocess': True}]}
+    assert os.path.isfile(
+        os.path.join(model_dir, "standalone_data", "train.%s" % config["source"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "standalone_data", "train.%s" % config["target"])
+    )
+    assert not os.path.isdir(os.path.join(model_dir, "data"))
+
+    model_dir = _run_framework(
+        tmpdir, "standalone1", "preprocess --build_model", parent="standalone0", config = {"data": {"sample": 100}}
+    )
+    config = _read_config(model_dir)
+    assert config["model"] == "standalone1"
+    assert config["modelType"] == "standalone"
+    assert config["data"] == {'sample': 100, 'sample_dist': [{'distribution': [['train', 1]], 'path': '${MODEL_DIR}/standalone_data', 'no_preprocess': True}]}
+    assert os.path.isfile(
+        os.path.join(model_dir, "standalone_data", "train.%s" % config["source"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "standalone_data", "train.%s" % config["target"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "data", "train.%s" % config["source"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "data", "train.%s" % config["target"])
+    )
+
+    model_dir = _run_framework(
+        tmpdir, "standalone2", "train", parent="standalone1"
+    )
+    config = _read_config(model_dir)
+    assert config["model"] == "standalone2"
+    assert config["modelType"] == "standalone"
+    assert config["data"] == {'sample': 100, 'sample_dist': [{'distribution': [['train', 1]], 'path': '${MODEL_DIR}/standalone_data', 'no_preprocess': True}]}
+    assert os.path.isfile(
+        os.path.join(model_dir, "standalone_data", "train.%s" % config["source"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "standalone_data", "train.%s" % config["target"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "data", "train.%s" % config["source"])
+    )
+    assert os.path.isfile(
+        os.path.join(model_dir, "data", "train.%s" % config["target"])
+    )
+
+
 def _test_buildvocab(tmpdir, run_num, multi=False):
 
     sides = {}

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -806,21 +806,31 @@ def test_preprocess_train_chain(tmpdir):
 
 
 def test_preprocess_as_standalone_model(tmpdir):
-    model_dir = _run_framework(
-        tmpdir, "checkpoint0", "train", config=config_base
-    )
+    model_dir = _run_framework(tmpdir, "checkpoint0", "train", config=config_base)
     config = _read_config(model_dir)
     assert config["model"] == "checkpoint0"
     assert config["modelType"] == "checkpoint"
     assert not os.path.isdir(os.path.join(model_dir, "data"))
 
     model_dir = _run_framework(
-        tmpdir, "standalone0", "preprocess --build_model standalone", parent="checkpoint0"
+        tmpdir,
+        "standalone0",
+        "preprocess --build_model standalone",
+        parent="checkpoint0",
     )
     config = _read_config(model_dir)
     assert config["model"] == "standalone0"
     assert config["modelType"] == "standalone"
-    assert config["data"] == {'sample': 251, 'sample_dist': [{'distribution': [['train', 1]], 'path': '${MODEL_DIR}/standalone_data', 'no_preprocess': True}]}
+    assert config["data"] == {
+        "sample": 251,
+        "sample_dist": [
+            {
+                "distribution": [["train", 1]],
+                "path": "${MODEL_DIR}/standalone_data",
+                "no_preprocess": True,
+            }
+        ],
+    }
     assert os.path.isfile(
         os.path.join(model_dir, "standalone_data", "train.%s" % config["source"])
     )
@@ -830,12 +840,25 @@ def test_preprocess_as_standalone_model(tmpdir):
     assert not os.path.isdir(os.path.join(model_dir, "data"))
 
     model_dir = _run_framework(
-        tmpdir, "standalone1", "preprocess --build_model", parent="standalone0", config = {"data": {"sample": 100}}
+        tmpdir,
+        "standalone1",
+        "preprocess --build_model",
+        parent="standalone0",
+        config={"data": {"sample": 100}},
     )
     config = _read_config(model_dir)
     assert config["model"] == "standalone1"
     assert config["modelType"] == "standalone"
-    assert config["data"] == {'sample': 100, 'sample_dist': [{'distribution': [['train', 1]], 'path': '${MODEL_DIR}/standalone_data', 'no_preprocess': True}]}
+    assert config["data"] == {
+        "sample": 100,
+        "sample_dist": [
+            {
+                "distribution": [["train", 1]],
+                "path": "${MODEL_DIR}/standalone_data",
+                "no_preprocess": True,
+            }
+        ],
+    }
     assert os.path.isfile(
         os.path.join(model_dir, "standalone_data", "train.%s" % config["source"])
     )
@@ -849,13 +872,20 @@ def test_preprocess_as_standalone_model(tmpdir):
         os.path.join(model_dir, "data", "train.%s" % config["target"])
     )
 
-    model_dir = _run_framework(
-        tmpdir, "standalone2", "train", parent="standalone1"
-    )
+    model_dir = _run_framework(tmpdir, "standalone2", "train", parent="standalone1")
     config = _read_config(model_dir)
     assert config["model"] == "standalone2"
     assert config["modelType"] == "standalone"
-    assert config["data"] == {'sample': 100, 'sample_dist': [{'distribution': [['train', 1]], 'path': '${MODEL_DIR}/standalone_data', 'no_preprocess': True}]}
+    assert config["data"] == {
+        "sample": 100,
+        "sample_dist": [
+            {
+                "distribution": [["train", 1]],
+                "path": "${MODEL_DIR}/standalone_data",
+                "no_preprocess": True,
+            }
+        ],
+    }
     assert os.path.isfile(
         os.path.join(model_dir, "standalone_data", "train.%s" % config["source"])
     )


### PR DESCRIPTION
This a first draft for "stem model" approach (refs #57226).

Before going any further, I would like to validate it with you. Maybe I am missing something.

Done so far : 

- stem model is expected to contain "data" directory with preprocessed data and a checkpoint : similar to a preprocess model but also with all the necessary preprocess resources (alignment model etc)
- it shouldn't contain "data" field in the model configuration
    - this field is built automatically from the additional user configuration (if any) and using "data" directory
    - user data is preprocessed, data from "data" directory is not preprocessed
- stem model can be used for both 'preprocess' and 'train' command
- stem model always produces another stem model (since we need to keep the data for all the following models)
- stem model is produced via 'preprocess' command with '--build_model stem' option

TODO : 
- procedure to release a stem model