### PR TITLE
Stop the beat requests after a period of inactivity

### DIFF
--- a/nmtwizard/beat_service.py
+++ b/nmtwizard/beat_service.py
@@ -1,5 +1,6 @@
 """Define the beat service to interact with the task launcher."""
 
+import contextlib
 import time
 import threading
 import requests
@@ -8,11 +9,18 @@ from nmtwizard.logger import get_logger
 
 logger = get_logger(__name__)
 
+_stop_beat = threading.Event()
+_beat_thread = None
+_last_activity = None
+_last_activity_lock = threading.Lock()
 
-def start_beat_service(container_id, url, task_id, interval=30):
-    """Start a background service that sends a HTTP GET request to:
 
-    url/beat/task_id?container_id=container_id&duration=interval
+def start_beat_service(
+    container_id, url, task_id, interval=30, inactivity_timeout=None
+):
+    """Start a background service that sends HTTP PUT requests to:
+
+    url/task/beat/task_id?container_id=container_id&duration=interval
 
     every `interval` seconds.
     """
@@ -22,6 +30,9 @@ def start_beat_service(container_id, url, task_id, interval=30):
             "CALLBACK_URL or task_id is unset; beat service will be disabled"
         )
         return
+    if beat_service_is_running():
+        logger.warning("The beat service is already running")
+        return
 
     request_params = {"container_id": container_id, "duration": str(interval * 2)}
 
@@ -30,11 +41,57 @@ def start_beat_service(container_id, url, task_id, interval=30):
 
     def _beat_loop():
         while True:
-            time.sleep(interval)
+            if _stop_beat.wait(interval):
+                break
+            if inactivity_timeout is not None:
+                with _last_activity_lock:
+                    if (
+                        _last_activity is not None
+                        and time.time() - _last_activity > inactivity_timeout
+                    ):
+                        logger.warning(
+                            "No process activity after %d seconds. Stopping the beat requests.",
+                            inactivity_timeout,
+                        )
+                        break
             _beat()
 
     _beat()  # First beat in the main thread to fail for wrong url.
     logger.info("Starting the beat service to %s with interval %d", url, interval)
-    notify_thread = threading.Thread(target=_beat_loop)
-    notify_thread.daemon = True
-    notify_thread.start()
+    global _beat_thread
+    _beat_thread = threading.Thread(target=_beat_loop)
+    _beat_thread.daemon = True
+    _beat_thread.start()
+
+
+def stop_beat_service():
+    """Stop the beat service."""
+    if beat_service_is_running():
+        _stop_beat.set()
+        _beat_thread.join()
+        _stop_beat.clear()
+
+
+def beat_service_is_running():
+    """Returns True if the beat service is currently running."""
+    return _beat_thread is not None and _beat_thread.is_alive()
+
+
+@contextlib.contextmanager
+def monitor_activity():
+    monitor = _ActivityMonitor()
+    monitor.notify()
+    yield monitor
+    monitor.stop()
+
+
+class _ActivityMonitor:
+    def notify(self):
+        global _last_activity
+        with _last_activity_lock:
+            _last_activity = time.time()
+
+    def stop(self):
+        global _last_activity
+        with _last_activity_lock:
+            _last_activity = None

--- a/nmtwizard/utility.py
+++ b/nmtwizard/utility.py
@@ -170,6 +170,12 @@ class Utility(abc.ABC):
             help="Interval of beat requests in seconds.",
         )
         parser.add_argument(
+            "--beat_inactivity_timeout",
+            default=3600,
+            type=int,
+            help="Stop the beat requests after this many seconds of inactivity in monitored execution.",
+        )
+        parser.add_argument(
             "--statistics_url",
             default=None,
             help=(
@@ -244,7 +250,11 @@ class Utility(abc.ABC):
         self._image = args.image
 
         start_beat_service(
-            os.uname()[1], args.beat_url, args.task_id, interval=args.beat_interval
+            os.uname()[1],
+            args.beat_url,
+            args.task_id,
+            interval=args.beat_interval,
+            inactivity_timeout=args.beat_inactivity_timeout,
         )
 
         self._storage = StorageClient(

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 black==21.4b2
 flake8==3.9.*
 pytest==4.*
+requests-mock==1.*


### PR DESCRIPTION
In rare cases It can happen that the preprocessing gets stuck while processing a batch. The PR adds an inactivity timeout (1h by default). If no new results are available after this time, we stop the background beat requests that are sent to the task launcher. The task launcher will then mark this task as expired and will terminate it.