### PR TITLE
Log length filter

### DIFF
--- a/nmtwizard/preprocess/operators/length_filter.py
+++ b/nmtwizard/preprocess/operators/length_filter.py
@@ -69,7 +69,7 @@ class LengthFilter(prepoperator.Filter):
 
         max_words_ratio = config.get("max_words_ratio")
         if max_words_ratio is not None:
-            message_max_words_ratio = "Exceeds max word length ratio (%.2f) (Src length : %d Tgt legth : %d Ratio : %.2f)"
+            message_max_words_ratio = "Exceeds max word length ratio (%.2f) (Src length : %d Tgt length : %d Ratio : %.2f)"
             filters.append(
                 lambda tu: (
                     len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0])

--- a/nmtwizard/preprocess/operators/length_filter.py
+++ b/nmtwizard/preprocess/operators/length_filter.py
@@ -52,23 +52,23 @@ class LengthFilter(prepoperator.Filter):
 
         min_words_ratio = config.get("min_words_ratio")
         if min_words_ratio is not None:
-            message_min_words_ratio = "Inferior to min word length ratio"
+            message_min_words_ratio = "Inferior to min word length ratio (%.2f) (Src length : %d Tgt legth : %d Ratio : %.2f)"
             filters.append(
                 lambda tu: (
                     len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0])
                     < min_words_ratio,
-                    message_min_words_ratio,
+                    message_min_words_ratio % (min_words_ratio, len(tu.src_tok.tokens[0]), len(tu.tgt_tok.tokens[0]), len(tu.src_tok.tokens[0])/len(tu.tgt_tok.tokens[0]))
                 )
             )
 
         max_words_ratio = config.get("max_words_ratio")
         if max_words_ratio is not None:
-            message_max_words_ratio = "Exceeds max word length ratio"
+            message_max_words_ratio = "Exceeds max word length ratio (%.2f) (Src length : %d Tgt legth : %d Ratio : %.2f)"
             filters.append(
                 lambda tu: (
                     len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0])
                     > max_words_ratio,
-                    message_max_words_ratio,
+                    message_max_words_ratio % (max_words_ratio, len(tu.src_tok.tokens[0]), len(tu.tgt_tok.tokens[0]), len(tu.src_tok.tokens[0])/len(tu.tgt_tok.tokens[0]))
                 )
             )
 

--- a/nmtwizard/preprocess/operators/length_filter.py
+++ b/nmtwizard/preprocess/operators/length_filter.py
@@ -52,7 +52,7 @@ class LengthFilter(prepoperator.Filter):
 
         min_words_ratio = config.get("min_words_ratio")
         if min_words_ratio is not None:
-            message_min_words_ratio = "Inferior to min word length ratio (%.2f) (Src length : %d Tgt legth : %d Ratio : %.2f)"
+            message_min_words_ratio = "Inferior to min word length ratio (%.2f) (Src length : %d Tgt length : %d Ratio : %.2f)"
             filters.append(
                 lambda tu: (
                     len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0])

--- a/nmtwizard/preprocess/operators/length_filter.py
+++ b/nmtwizard/preprocess/operators/length_filter.py
@@ -57,7 +57,13 @@ class LengthFilter(prepoperator.Filter):
                 lambda tu: (
                     len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0])
                     < min_words_ratio,
-                    message_min_words_ratio % (min_words_ratio, len(tu.src_tok.tokens[0]), len(tu.tgt_tok.tokens[0]), len(tu.src_tok.tokens[0])/len(tu.tgt_tok.tokens[0]))
+                    message_min_words_ratio
+                    % (
+                        min_words_ratio,
+                        len(tu.src_tok.tokens[0]),
+                        len(tu.tgt_tok.tokens[0]),
+                        len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0]),
+                    ),
                 )
             )
 
@@ -68,7 +74,13 @@ class LengthFilter(prepoperator.Filter):
                 lambda tu: (
                     len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0])
                     > max_words_ratio,
-                    message_max_words_ratio % (max_words_ratio, len(tu.src_tok.tokens[0]), len(tu.tgt_tok.tokens[0]), len(tu.src_tok.tokens[0])/len(tu.tgt_tok.tokens[0]))
+                    message_max_words_ratio
+                    % (
+                        max_words_ratio,
+                        len(tu.src_tok.tokens[0]),
+                        len(tu.tgt_tok.tokens[0]),
+                        len(tu.src_tok.tokens[0]) / len(tu.tgt_tok.tokens[0]),
+                    ),
                 )
             )
 


### PR DESCRIPTION
I don't like calculating lengths and ratio twice, but I don't know how to avoid it in a lambda function.