### PR TITLE
Bypass postprocess in score and return the original target

### DIFF
--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1615,9 +1615,10 @@ def is_joint_vocab(vocabulary_config):
 
 
 def add_target_to_score_output(target_path, score_path):
-    with open(target_path) as tf, open(score_path) as sf:
-        scores = [x.split(" ||| ")[0] for x in sf.readlines()]
-        target_lines = tf.readlines()
-    with open(score_path, "w") as sf:
-        for score, line in zip(scores, target_lines):
-            sf.write(f"{score} ||| {line}")
+    output_path = score_path + ".out"
+    with open(target_path) as tf, open(score_path) as sf, open(output_path, "w") as of:
+        for line_score, line_target in zip(sf, tf):
+            score = line_score.split(" ||| ")[0]
+            of.write(f"{score} ||| {line_target}")
+    os.remove(score_path)
+    os.rename(output_path, score_path)

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1622,7 +1622,6 @@ def add_target_to_score_output(target_path, score_path):
     with open(target_path) as tf, open(score_path) as sf:
         scores = [x.split(" ||| ")[0] for x in sf.readlines()]
         target_lines = tf.readlines()
-    output_path = score_path
     with open(score_path, "w") as sf:
         for score, line in zip(scores, target_lines):
             sf.write(f"{score} ||| {line}")

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1544,16 +1544,12 @@ def bundle_dependencies(objects, config, local_config, keep_all=False):
 
 def should_check_integrity(f):
     """Returns True if f should be checked for integrity."""
-    return (
-        f
-        not in (
-            "README.md",
-            "TRAINING_LOG",
-            "checksum.md5",
-            "data",
-        )
-        and not f.startswith(".")
-    )
+    return f not in (
+        "README.md",
+        "TRAINING_LOG",
+        "checksum.md5",
+        "data",
+    ) and not f.startswith(".")
 
 
 def file_stats(path):


### PR DESCRIPTION
I left the postprocess application, because it also normalizes scores (in loader). Let me know if it seems ok to you, or maybe we should more score normalization elsewhere ?