### PR TITLE
Always validate inference options

### DIFF
--- a/nmtwizard/config.py
+++ b/nmtwizard/config.py
@@ -224,6 +224,13 @@ def get_config_version(config):
     return 2 if is_v2_config(config) else 1
 
 
+def validate(config):
+    """Raises an exception if the configuration is incorrect."""
+    inference_options = config.get("inference_options")
+    if inference_options is not None:
+        validate_inference_options(inference_options, config)
+
+
 def ensure_operators_name(config):
     """Make sure all operators in model configuration have a unique name."""
     if is_v1_config(config):

--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1732,6 +1732,7 @@ class Framework(utility.Utility):
         return build_info
 
     def _finalize_config(self, config, training=True):
+        config_util.validate(config)
         config_util.ensure_operators_name(config)
         config = config_util.old_to_new_config(config)
         config = utility.resolve_environment_variables(

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -517,6 +517,14 @@ def test_train_chain(tmpdir):
     assert DummyCheckpoint(model_dir).index() == 1
 
 
+def test_train_invalid_inference_options(tmpdir):
+    config = config_base.copy()
+    config["inference_options"] = {"jsonSchema": {}}
+
+    with pytest.raises(ValueError, match="json_schema"):
+        _run_framework(tmpdir, "model0", "train", config=config)
+
+
 @pytest.mark.parametrize(
     "config,custom_field,new_field,mode,expected_field",
     [


### PR DESCRIPTION
Currently the inference options are only verified when the model is released, but it's better to report the error as early as possible.