### PR TITLE
Save the checksum of each model file in manifest.json

### DIFF
--- a/nmtwizard/framework.py
+++ b/nmtwizard/framework.py
@@ -1795,14 +1795,23 @@ def bundle_dependencies(objects, config, local_config, keep_all=False):
         return config
 
 
-def should_check_integrity(f):
-    """Returns True if f should be checked for integrity."""
-    return f not in (
+def should_check_integrity(filename):
+    """Returns True if filename should be checked for integrity."""
+    if filename.startswith("."):
+        return False
+
+    ignored = (
         "README.md",
         "TRAINING_LOG",
         "checksum.md5",
         "data",
-    ) and not f.startswith(".")
+    )
+
+    directory = os.path.dirname(filename)
+    if directory:
+        return should_check_integrity(directory)
+
+    return filename not in ignored
 
 
 def file_stats(path):

--- a/nmtwizard/utils.py
+++ b/nmtwizard/utils.py
@@ -26,6 +26,13 @@ class ScoreType(enum.Enum):
     NORMALIZED_NLL = 3
 
 
+def md5file(path, buffer_size=16777216):
+    """Computes the MD5 hash of the given file."""
+    md5 = hashlib.md5()
+    _update_hash(path, md5, buffer_size)
+    return md5.hexdigest()
+
+
 def md5files(files, buffer_size=16777216):
     """Computes the combined MD5 hash of multiple files, represented as a list
     of (key, path).
@@ -43,13 +50,17 @@ def md5files(files, buffer_size=16777216):
             )
             m.update(sub_md5.encode("utf-8"))
         else:
-            with open(path, "rb") as f:
-                while True:
-                    data = f.read(buffer_size)
-                    if not data:
-                        break
-                    m.update(data)
+            _update_hash(path, m, buffer_size)
     return m.hexdigest()
+
+
+def _update_hash(path, hash_object, buffer_size):
+    with open(path, "rb") as f:
+        while True:
+            data = f.read(buffer_size)
+            if not data:
+                break
+            hash_object.update(data)
 
 
 def run_cmd(cmd, cwd=None, background=False):


### PR DESCRIPTION
This replaces the file `checksum.md5` which only contained a global MD5 checksum.